### PR TITLE
Remove fields only visible to authenticated users from display

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_guides_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.default.yml
@@ -31,19 +31,6 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: -20
-    region: content
-  field_content_owner:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 3
-    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -58,7 +45,9 @@ content:
     weight: 2
     region: content
 hidden:
+  content_moderation_control: true
   entitygroupfield: true
+  field_content_owner: true
   field_non_publishable_notes: true
   localgov_guides_description: true
   localgov_guides_list_format: true

--- a/config/default/core.entity_view_display.node.localgov_guides_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_page.default.yml
@@ -25,25 +25,12 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
-    region: content
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: -20
-    region: content
-  field_content_owner:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   localgov_page_components:
     type: entity_reference_entity_view
@@ -55,7 +42,9 @@ content:
     weight: 2
     region: content
 hidden:
+  content_moderation_control: true
   entitygroupfield: true
+  field_content_owner: true
   field_non_publishable_notes: true
   localgov_guides_parent: true
   localgov_guides_section_title: true

--- a/config/default/core.entity_view_display.node.localgov_news_article.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.default.yml
@@ -29,12 +29,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
-    region: content
-  content_moderation_control:
-    settings: {  }
-    third_party_settings: {  }
-    weight: -20
+    weight: 2
     region: content
   links:
     settings: {  }
@@ -57,9 +52,10 @@ content:
       view_mode: teaser
       link: false
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
 hidden:
+  content_moderation_control: true
   entitygroupfield: true
   field_media_image: true
   localgov_news_categories: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -35,20 +35,12 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_content_owner:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 12
-    region: content
   localgov_address:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 3
     region: content
   localgov_address_first_line:
     type: string
@@ -56,7 +48,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 3
+    weight: 2
     region: content
   localgov_destinations:
     type: entity_reference_entity_view
@@ -73,7 +65,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 7
+    weight: 4
     region: content
   localgov_link_to_map:
     type: link
@@ -85,7 +77,7 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    weight: 9
+    weight: 6
     region: content
   localgov_popular_topics:
     type: taxonomy_vertical_list
@@ -93,7 +85,7 @@ content:
     settings:
       title: 'Popular topics'
     third_party_settings: {  }
-    weight: 11
+    weight: 7
     region: content
   localgov_services_parent:
     type: entity_reference_label
@@ -101,7 +93,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 12
+    weight: 8
     region: content
   localgov_twitter:
     type: string
@@ -109,11 +101,12 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 8
+    weight: 5
     region: content
 hidden:
   content_moderation_control: true
   entitygroupfield: true
+  field_content_owner: true
   field_non_publishable_notes: true
   links: true
   localgov_common_tasks: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.default.yml
@@ -32,14 +32,6 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_content_owner:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 2
-    region: content
   localgov_page_components:
     type: entity_reference_entity_view
     label: hidden
@@ -52,6 +44,7 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
+  field_content_owner: true
   field_non_publishable_notes: true
   links: true
   localgov_common_tasks: true


### PR DESCRIPTION
So that the view looks closer to what an unauthenticated user will see. Admin tasks can be done in the admin interface rather than on the page itself. 