### PR TITLE
ECCW-404: Patch cludo interface to use custom template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,9 @@
             },
             "drupal/migmag": {
                 "Fix migmag_lookup exception when stubbing non-sql sources. See https://www.drupal.org/project/migmag/issues/3321292#comment-14785506": "https://www.drupal.org/files/issues/2022-11-14/migmag-remove_double_prepareRow-3321292_3.patch"
+            },
+            "drupal/cludo_search": {
+                "Remove search type to use custom template": "patches/cludo_search-0001.patch"
             }
         },
         "drupal-scaffold": {

--- a/patches/cludo_search-0001.patch
+++ b/patches/cludo_search-0001.patch
@@ -1,0 +1,11 @@
+--- js/cludo_search.js.orig	2023-02-10 17:47:17.603364085 +0000
++++ js/cludo_search.js	2023-02-10 17:47:22.253427853 +0000
+@@ -14,7 +14,7 @@
+         hideSearchFilters: drupalSettings.cludo_search.cludo_searchJS.hideSearchFilters,
+         language: 'en',
+         searchInputs: ["cludo-search-block-form","cludo-search-search-form"],
+-        type: 'inline'
++        //type: 'inline'
+       };
+     CludoSearch = new Cludo(cludoSettings);
+     CludoSearch.init();


### PR DESCRIPTION
The Cludo instance for ECC has been configured with a custom template, something that cludo now is loathe to do for clients. The custom template is selected by omitting the type selection, rather than selecting one of the two built-in templates. This patch removes that field from the API calls.