### PR TITLE
ECCW-401: Add noindex header

### DIFF
--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -108,6 +108,11 @@ http {
         # pattern with front controllers other than update.php in a future
         # release.
         location ~ \.php(/|$) {
+            # If we're outside of govuk then request no indexing, on the assumption that this is a non-production environment
+            if ($customhost !~* ".*\.gov\.uk") {
+                add_header X-Robots-Tag "noindex, follow" always;
+            }
+
             # Override host for health endpoint
             if ($uri = "/index.php/health")  {
                 set $customhost drupal;
@@ -126,6 +131,11 @@ http {
         }
 
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+            # If we're outside of govuk then request no indexing, on the assumption that this is a non-production environment
+            if ($customhost !~* ".*\.gov\.uk") {
+                add_header X-Robots-Tag "noindex, follow" always;
+            }
+
             try_files $uri @rewrite;
             expires max;
             log_not_found off;


### PR DESCRIPTION
This adds a no-index header when not served from gov.uk, to avoid indexing non-production environments.

On hold pending resolution of discussion in Jira