### PR TITLE
Revert #141  - ECCW-407-Reduce-size-of-image-on-media-with-text

### DIFF
--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -921,8 +921,7 @@ footer .lgd-footer__footer a {
   padding-top: clamp(var(--spacing), 3vw, var(--spacing-large))
 }
 
-.node--type-localgov-news-article picture>img,
-.media-with-text--default picture>img {
+.node--type-localgov-news-article picture>img {
   max-inline-size: 100%;
   block-size: auto;
   height: auto;


### PR DESCRIPTION
This reverts this change as the image appears to be being cropped unnecessarily. As such, we would like to examine if there's a more appropriate fix in Drupal.