### PR TITLE
ECCW-72: Analytics support

### DIFF
--- a/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.libraries.yml
+++ b/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.libraries.yml
@@ -2,3 +2,11 @@ oembed_cookies:
   version: VERSION
   js:
     js/oembed_cookies.js: {}
+  dependencies:
+    - core/jquery
+live_handler:
+  version: VERSION
+  js:
+    js/live_handler.js: {}
+  dependencies:
+    - core/jquery

--- a/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.module
+++ b/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.module
@@ -26,7 +26,7 @@ function ecc_cookie_compliance_preprocess_field(&$variables) {
 /**
  * Implements hook_page_attachments().
  *
- * @see \Drupal\big_pipe\Controller\BigPipeController::setNoJsCookie()
+ * Unconditionally adds the helper for cookie compliance to all pages.
  */
 function ecc_cookie_compliance_page_attachments(&$variables) {
   $variables['#attached']['library'][] = 'ecc_cookie_compliance/live_handler';

--- a/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.module
+++ b/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.module
@@ -6,7 +6,7 @@
  */
 function ecc_cookie_compliance_google_tag_snippets_alter(array &$snippets) {
     // Only add the script snippet if cookie compliance has been agreed.
-    $snippets['script'] = 'if (document.cookie.includes(\'analytics_cookies\')){ ' . $snippets['script'] . '}';
+    $snippets['script'] = 'window.gtm = function(){ ' . $snippets['script'] . '}; if (document.cookie.includes(\'analytics_cookies\')){ window.gtm(); }';
     $snippets['noscript'] = '';
 }
 
@@ -20,6 +20,16 @@ function ecc_cookie_compliance_preprocess_field(&$variables) {
   if ($formatter === 'oembed') {
     _cookies_video_media_oembed_handler($variables);
   }
+}
+
+
+/**
+ * Implements hook_page_attachments().
+ *
+ * @see \Drupal\big_pipe\Controller\BigPipeController::setNoJsCookie()
+ */
+function ecc_cookie_compliance_page_attachments(&$variables) {
+  $variables['#attached']['library'][] = 'ecc_cookie_compliance/live_handler';
 }
 
 

--- a/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
+++ b/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
@@ -12,13 +12,11 @@
       } else {
         $.each(document.cookie.split(/; */), function()  {
           var splitCookie = this.split('=');
-          console.log(splitCookie);
           if (splitCookie[0].indexOf('_ga') >= 0) {
             document.cookie = splitCookie[0] + '=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
           }
         });
       }
-      console.log(categories);
   })
 
 }) (jQuery)

--- a/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
+++ b/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * ecc_live_handler.js
+ *
+ * Triggers GTM load and GA clear as needed on live preference changes
+ */
+(function ($) {
+  
+    $(document).on('eu_cookie_compliance.changePreferences', function (event, categories) {
+      if (categories.indexOf('analytics_cookies') >= 0) {
+        window.gtm();
+      } else {
+        $.each(document.cookie.split(/; */), function()  {
+          var splitCookie = this.split('=');
+          console.log(splitCookie);
+          if (splitCookie[0].indexOf('_ga') >= 0) {
+            document.cookie = splitCookie[0] + '=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
+          }
+        });
+      }
+      console.log(categories);
+  })
+
+}) (jQuery)
+


### PR DESCRIPTION
This makes two changes to the analytics, to make the live experience better.

1. It wraps the analytics init script into a window function, so it can be triggered after page load, if the user agrees to other cookies
2. It listens to cookie consent change events and if analytics cookies are toggled it either calls the function from 1 or removes _ga cookies depending on the change.