### PR TITLE
ECCW-72: Improve cookie compliance

### DIFF
--- a/config/default/eu_cookie_compliance.settings.yml
+++ b/config/default/eu_cookie_compliance.settings.yml
@@ -56,7 +56,7 @@ better_support_for_screen_readers: false
 method: categories
 disabled_javascripts: 'google_analytics:modules/contrib/localgov_eu_cookie_compliance/js/deferred-ga-script-runner.js'
 automatic_cookies_removal: true
-allowed_cookies: ''
+allowed_cookies: "analytics_cookies:_ga*\r\nanalytics_cookies:_ga"
 consent_storage_method: do_not_store
 withdraw_message:
   value: "<h2>We use cookies on this site to enhance your user experience</h2>\r\n\r\n<p>You have given your consent for us to set cookies.</p>\r\n"

--- a/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.libraries.yml
+++ b/web/modules/custom/ecc_cookie_compliance/ecc_cookie_compliance.libraries.yml
@@ -10,3 +10,4 @@ live_handler:
     js/live_handler.js: {}
   dependencies:
     - core/jquery
+    - eu_cookie_compliance

--- a/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
+++ b/web/modules/custom/ecc_cookie_compliance/js/live_handler.js
@@ -4,20 +4,27 @@
  *
  * Triggers GTM load and GA clear as needed on live preference changes
  */
-(function ($) {
-  
+(function ($, Drupal) {
+
     $(document).on('eu_cookie_compliance.changePreferences', function (event, categories) {
       if (categories.indexOf('analytics_cookies') >= 0) {
         window.gtm();
-      } else {
-        $.each(document.cookie.split(/; */), function()  {
-          var splitCookie = this.split('=');
-          if (splitCookie[0].indexOf('_ga') >= 0) {
-            document.cookie = splitCookie[0] + '=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
-          }
-        });
-      }
-  })
+      };
 
-}) (jQuery)
+      // Enforce cookie validity every time category approvals change
+      // This way, any blocked cookies are removed as early as possible
+      // when settings change, without waiting for the interval.
+      Drupal.eu_cookie_compliance.BlockCookies();
+    });
+
+    $(document).ready(function() {
+      // Also clear unapproved cookies early on page load, before the interval
+      // is set up. This is useful in case a resident script has hooked into the
+      // navigate away event, and sets a cookie during the transition.
+      // While we can't stop that in a generic way, we can minimise the time it's
+      // available for.
+      Drupal.eu_cookie_compliance.BlockCookies();
+    })
+
+}) (jQuery, Drupal)
 


### PR DESCRIPTION
Set missing ga filters in the cookie compliance script, so they're cleared out automatically, and replace the direct cookie unsetting with calls to the eu cookie compliance one. Trigger the automated clear-down at a couple of additional points, to improve behaviour due to window navigation hooks setting unwanted cookies.