### PR TITLE
ECCW-535: Move noindex logic to environment variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,8 @@ deploy-to-dev:
                 secretRef: mysql-password
               - name: OPENID_CONNECT_PARAMS
                 secretRef: openid-connect-params
+              - name: X_ROBOTS_TAG
+                value: noindex
       EOF
     - az containerapp revision copy --name portal --resource-group rg-ecc-portal-uks-dev --yaml revision.yml --subscription "Essex County Council (Portal)"
   rules:
@@ -232,6 +234,8 @@ deploy-to-preprod:
                 secretRef: mysql-password
               - name: OPENID_CONNECT_PARAMS
                 secretRef: openid-connect-params
+              - name: X_ROBOTS_TAG
+                value: noindex
       EOF
     - echo "Creating new revision of Container App"
     - az containerapp revision copy --name portal --resource-group rg-ecc-portal-uks-pre --yaml revision.yml --subscription "Essex County Council (Portal)"
@@ -302,6 +306,8 @@ deploy-to-prod:
                 secretRef: mysql-password
               - name: OPENID_CONNECT_PARAMS
                 secretRef: openid-connect-params
+              - name: X_ROBOTS_TAG
+                value: noindex
       EOF
     - az containerapp revision copy --name portal --resource-group rg-ecc-portal-uks-prod --yaml revision.yml --subscription "Essex County Council (Portal)"
   rules:

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,16 +1,5 @@
-FROM docker.io/nginx:1.22 as nginx-drupal
+FROM nginx
 
-RUN apt-get update \
-  && apt-get install -y \
-  wget \
-  && mkdir -p /drupal/web/sites/default/files \
-  && echo "Server running" > /drupal/web/index.html \
-  && usermod -d /drupal www-data
-
-RUN chown -hR 33:33 /drupal
-
+ENV X_ROBOTS_TAG="none"
 COPY --chown=www-data:www-data --from=portal-drupal-fpm /drupal /drupal
-
-COPY nginx-conf/nginx.conf /etc/nginx/nginx.conf
-
-EXPOSE 80
+COPY nginx-conf/nginx.conf /etc/nginx/templates/default.conf.template

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,228 +1,200 @@
-worker_processes  1;
+server {
+    listen 80;
+    server_name localhost;
+    root /drupal/web; ## <-- Your only path reference.
 
-events {
-    worker_connections  1024;
-}
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
 
-http {
-    include       mime.types;
-    default_type  application/octet-stream;
-
-    sendfile        on;
-    server_tokens off;
-    keepalive_timeout  65;
-
-    client_max_body_size 120M;
-
-    server {
-        listen 80;
-        server_name localhost;
-        root /drupal/web; ## <-- Your only path reference.
-
-        access_log /var/log/nginx/access.log;
-        error_log /var/log/nginx/error.log;
-
-
-        location = /favicon.ico {
-            log_not_found off;
-            access_log off;
-        }
-
-        location = /robots.txt {
-            allow all;
-            log_not_found off;
-            access_log off;
-        }
-
-        # Very rarely should these ever be accessed outside of your lan
-        location ~* \.(txt|log)$ {
-            allow 192.168.0.0/16;
-            deny all;
-        }
-
-        location ~ \..*/.*\.php$ {
-            return 403;
-        }
-
-        location ~ ^/sites/.*/private/ {
-            return 403;
-        }
-
-        # Block access to scripts in site files directory
-        location ~ ^/sites/[^/]+/files/.*\.php$ {
-            deny all;
-        }
-
-        # Allow "Well-Known URIs" as per RFC 5785
-        location ~* ^/.well-known/ {
-            allow all;
-        }
-
-        # Block access to "hidden" files and directories whose names begin with a
-        # period. This includes directories used by version control systems such
-        # as Subversion or Git to store control files.
-        location ~ (^|/)\. {
-            return 403;
-        }
-
-        location / {
-            # try_files $uri @rewrite; # For Drupal <= 6
-            try_files $uri /index.php?$query_string; # For Drupal >= 7
-        }
-
-        location @rewrite {
-            #rewrite ^/(.*)$ /index.php?q=$1; # For Drupal <= 6
-            rewrite ^ /index.php; # For Drupal >= 7
-        }
-
-        # Don't allow direct access to PHP files in the vendor directory.
-        location ~ /vendor/.*\.php$ {
-            deny all;
-            return 404;
-        }
-
-        # Protect files and directories from prying eyes.
-        location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|composer\.(lock|json)$|web\.config$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
-            deny all;
-            return 404;
-        }
-
-        # Determine HTTP host to use based on forwarding headers
-        set $customhost $http_host;
-        if ($http_x_forwarded_host != '') {
-            set $customhost $http_x_forwarded_host;
-        }
-        if ($http_x_original_host != '') {
-            set $customhost $http_x_original_host;
-        }
-
-        # In Drupal 8, we must also match new paths where the '.php' appears in
-        # the middle, such as update.php/selection. The rule we use is strict,
-        # and only allows this pattern with the update.php front controller.
-        # This allows legacy path aliases in the form of
-        # blog/index.php/legacy-path to continue to route to Drupal nodes. If
-        # you do not have any paths like that, then you might prefer to use a
-        # laxer rule, such as:
-        #   location ~ \.php(/|$) {
-        # The laxer rule will continue to work if Drupal uses this new URL
-        # pattern with front controllers other than update.php in a future
-        # release.
-        location ~ \.php(/|$) {
-            # If we're outside of govuk then request no indexing, on the assumption that this is a non-production environment
-            if ($customhost !~* ".*\.gov\.uk") {
-                add_header X-Robots-Tag "noindex, follow" always;
-            }
-
-            # Override host for health endpoint
-            if ($uri = "/index.php/health")  {
-                set $customhost drupal;
-            }
-            fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
-            include fastcgi_params;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param PATH_INFO $fastcgi_path_info;
-            fastcgi_param HTTP_HOST $customhost;
-            # make drupal understand clients were talking https to the loadbalancer
-            fastcgi_param HTTPS on;
-            fastcgi_param HTTP_SCHEME https;
-            fastcgi_intercept_errors on;
-            # changed from drupal-fpm to localhost for azure containers
-            fastcgi_pass localhost:9000;
-        }
-
-        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-            # TODO: This doesn't work as expected, see https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
-            # If we're outside of govuk then request no indexing, on the assumption that this is a non-production environment
-            # if ($customhost !~* ".*\.gov\.uk") {
-            #     add_header X-Robots-Tag "noindex, follow" always;
-            # }
-
-            try_files $uri @rewrite;
-            expires max;
-            log_not_found off;
-        }
-
-        # Fighting with Styles? This little gem is amazing.
-        # location ~ ^/sites/.*/files/imagecache/ { # For Drupal <= 6
-        location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
-            try_files $uri @rewrite;
-        }
-
-        # Handle private files through Drupal. Private file's path can come
-        # with a language prefix.
-        location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
-            try_files $uri /index.php?$query_string;
-        }
-
-        rewrite '^(/News/.*)$' https://$customhost/news permanent;
-        rewrite '^(/Activities/.*)$' https://$customhost/leisure-culture-local-heritage permanent;
-        rewrite '^(/Publications/.*)$' https://$customhost/ permanent;
-        rewrite '^(/privacy-notices/.*)$' https://$customhost/topic/privacy-and-data-protection permanent;
-        rewrite '^(/customer-services/.*)$' https://$customhost/topic/contact-us permanent;
-        rewrite '^(/Libraries-Archives/.*)$' https://$customhost/essex-libraries permanent;
-        rewrite '^(/Your-Council/Pages/.*)$' https://$customhost/topic/running-the-council permanent;
-        rewrite '^(/enforcement-policy/.*)$' https://$customhost/trading-standards-policies-and-procedures/trading-standards-enforcement-policy permanent;
-        rewrite '^(/Transport and Roads/.*)$' https://$customhost/roads-streets-and-transport permanent;
-        rewrite '^(/Business-Partners/Pages/.*)$' https://$customhost/topic/business permanent;
-        rewrite '^(/Education-Schools/Pages/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Births Ceremonies Deaths/.*)$' https://$customhost/topic/births-ceremonies-deaths permanent;
-        rewrite '^(/Your-Council/Councillors/.*)$' https://$customhost/your-councillor permanent;
-        rewrite '^(/Health-Social-Care/Health/.*)$' https://$customhost/topic/adult-social-care-and-health permanent;
-        rewrite '^(/Business-Partners/Partners/.*)$' https://$customhost/topic/business permanent;
-        rewrite '^(/Business-Partners/licences/.*)$' https://$customhost/topic/licences permanent;
-        rewrite '^(/Community-Safety/Communities/.*)$' https://$customhost/leisure-culture-local-heritage permanent;
-        rewrite '^(/Your-Council/Your-Right-Know/.*)$' https://$customhost/request-information permanent;
-        rewrite '^(/Education-Schools/Schools/Dates/.*)$' https://$customhost/school-terms-and-holidays permanent;
-        rewrite '^(/Education-Schools/Travel-School/.*)$' https://$customhost/school-transport permanent;
-        rewrite '^(/Environment Planning/Environment/.*)$' https://$customhost/topic/planning-land-recycling permanent;
-        rewrite '^(/Health-Social-Care/Care-Children/.*)$' https://$customhost/topic/children-young-people-and-families permanent;
-        rewrite '^(/Your-Council/Strategies-Policies/.*)$' https://$customhost/topic/running-the-council permanent;
-        rewrite '^(/Business-Partners/Traded_Services/.*)$' https://$customhost/services-we-sell permanent;
-        rewrite '^(/Education-Schools/Apprenticeships/.*)$' https://$customhost/jobs-volunteering-apprenticeships/apprenticeships permanent;
-        rewrite '^(/Education-Schools/Post-16-options/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Education-Schools/Schools/Learning/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Your-Council/Consultation-Feedback/.*)$' https://$customhost/get-involved permanent;
-        rewrite '^(/Business-Partners/Supplying-Council/.*)$' https://$customhost/supply-the-council permanent;
-        rewrite '^(/Your-Council/Local-Government-Essex/.*)$' https://$customhost/topic/running-the-council permanent;
-        rewrite '^(/business-advice-and-charging-policy/.*)$' https://$customhost/trading-standards-policies-and-procedures/trading-standards-business-advice-and-charging-policy permanent;
-        rewrite '^(/Education-Schools/Schools/Admissions/.*)$' https://$customhost/topic/admissions permanent;
-        rewrite '^(/Environment Planning/Recycling-Waste/.*)$' https://$customhost/waste-recycling permanent;
-        rewrite '^(/Education-Schools/Early-Years-Childcare/.*)$' https://$customhost/topic/early-years-and-childcare permanent;
-        rewrite '^(/Your-Council/Committees-Decision-Making/.*)$' https://$customhost/how-decisions-are-made permanent;
-        rewrite '^(/Business-Partners/Business-Advice-Support/.*)$' https://$customhost/support-for-businesses permanent;
-        rewrite '^(/Education-Schools/Schools/Work-Experience/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Environment Planning/Development-in-Essex/.*)$' https://$customhost/topic/planning-development permanent;
-        rewrite '^(/Your-Council/Council-Spending/council-tax/.*)$' https://$customhost/spending-and-council-tax permanent;
-        rewrite '^(/Education-Schools/Schools/Attending-School/.*)$' https://$customhost/school-attendance-and-absence permanent;
-        rewrite '^(/Environment Planning/Strategic-Environment/.*)$' https://$customhost/topic/planning-land-recycling permanent;
-        rewrite '^(/Education-Schools/Schools/Educational-builds/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Your-Council/Local-Government-Essex/Documents/.*)$' https://$customhost/how-decisions-are-made/how-decisions-are-made permanent;
-        rewrite '^(/Business-Partners/Trading-Standards/businesses/.*)$' https://$customhost/trading-standards-for-businesses permanent;
-        rewrite '^(/Education-Schools/Schools/Pupil-Parent-Support/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Your-Council/Council-Spending/council-contracts/.*)$' https://$customhost/spending-and-council-tax/finance-and-spending-breakdowns permanent;
-        rewrite '^(/Community-Safety/Trading-Standards-for-Consumers/.*)$' https://$customhost/trading-standards-for-consumers permanent;
-        rewrite '^(/Education-Schools/Schools/Special-Education-Needs/.*)$' https://$customhost/special-educational-needs-and-disabilities permanent;
-        rewrite '^(/Environment Planning/Minerals-Waste-Planning-Team/.*)$' https://$customhost/topic/planning-development permanent;
-        rewrite '^(/Education-Schools/Schools/Discipline-and-Exclusion/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Your-Council/Strategies-Policies/Code-of-Governance/.*)$' https://$customhost/governance permanent;
-        rewrite '^(/Education-Schools/Schools/Delivering-Education-Essex/.*)$' https://$customhost/topic/schools-and-learning permanent;
-        rewrite '^(/Education-Schools/Schools/becoming-a-school-governor/.*)$' https://$customhost/school-governors permanent;
-        rewrite '^(/Your-Council/Councillors/Allowances/Documents/Report/.*)$' https://$customhost/governance permanent;
-        rewrite '^(/Business-Partners/Partners/Community-initiatives-fund/.*)$' https://$customhost/leisure-culture-local-heritage/culture-and-communities permanent;
-        rewrite '^(/Health-Social-Care/Families-and-childrens-social-care/.*)$' https://$customhost/topic/children-young-people-and-families permanent;
-        rewrite '^(/Education-Schools/Early-Years-Childcare/Find-a-provider/.*)$' https://$customhost/find-a-childcare-provider permanent;
-        rewrite '^(/Environment Planning/Environment/local-environment/Pages/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
-        rewrite '^(/Education-Schools/Schools/Admissions/Catchment_Area_Checker/.*)$' https://$customhost/find-a-school permanent;
-        rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/Blue-Badges/.*)$' https://$customhost/blue-badge permanent;
-        rewrite '^(/Your-Council/Local-Government-Essex/ECC-Structure/Senior-Officers/.*)$' https://$customhost/senior-officers permanent;
-        rewrite '^(/Environment Planning/Environment/local-environment/Trees and hedges/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
-        rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/Blue-Badges-Old/.*)$' https://$customhost/blue-badge permanent;
-        rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/budgets-payments/.*)$' https://$customhost/personal-budgets-and-direct-payments permanent;
-        rewrite '^(/Environment Planning/Environment/local-environment/Gypsy-Traveller-Services/.*)$' https://$customhost/gypsies-travellers permanent;
-        rewrite '^(/Environment Planning/Environment/local-environment/Wildlife-and-Biodiversity/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
-        rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/charging-for-care-services/.*)$' https://$customhost/topic/paying-for-care-and-support permanent;
-        rewrite '^(/Health-Social-Care/Families-and-childrens-social-care/Protecting-Vulnerable-Children/.*)$' https://$customhost/report-a-concern-about-a-child permanent;
-        rewrite '^(/topic/adult-social-care-and-health/redirect/.*)$' https://$customhost/topic/adult-social-care-and-health permanent;
-
+    location = /favicon.ico {
+        log_not_found off;
+        access_log off;
     }
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
+    }
+
+    # Very rarely should these ever be accessed outside of your lan
+    location ~* \.(txt|log)$ {
+        allow 192.168.0.0/16;
+        deny all;
+    }
+
+    location ~ \..*/.*\.php$ {
+        return 403;
+    }
+
+    location ~ ^/sites/.*/private/ {
+        return 403;
+    }
+
+    # Block access to scripts in site files directory
+    location ~ ^/sites/[^/]+/files/.*\.php$ {
+        deny all;
+    }
+
+    # Allow "Well-Known URIs" as per RFC 5785
+    location ~* ^/.well-known/ {
+        allow all;
+    }
+
+    # Block access to "hidden" files and directories whose names begin with a
+    # period. This includes directories used by version control systems such
+    # as Subversion or Git to store control files.
+    location ~ (^|/)\. {
+        return 403;
+    }
+
+    location / {
+        # try_files $uri @rewrite; # For Drupal <= 6
+        try_files $uri /index.php?$query_string; # For Drupal >= 7
+    }
+
+    location @rewrite {
+        #rewrite ^/(.*)$ /index.php?q=$1; # For Drupal <= 6
+        rewrite ^ /index.php; # For Drupal >= 7
+    }
+
+    # Don't allow direct access to PHP files in the vendor directory.
+    location ~ /vendor/.*\.php$ {
+        deny all;
+        return 404;
+    }
+
+    # Protect files and directories from prying eyes.
+    location ~* \.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|composer\.(lock|json)$|web\.config$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$ {
+        deny all;
+        return 404;
+    }
+
+    # Determine HTTP host to use based on forwarding headers
+    set $customhost $http_host;
+    if ($http_x_forwarded_host != '') {
+        set $customhost $http_x_forwarded_host;
+    }
+    if ($http_x_original_host != '') {
+        set $customhost $http_x_original_host;
+    }
+
+    # In Drupal 8, we must also match new paths where the '.php' appears in
+    # the middle, such as update.php/selection. The rule we use is strict,
+    # and only allows this pattern with the update.php front controller.
+    # This allows legacy path aliases in the form of
+    # blog/index.php/legacy-path to continue to route to Drupal nodes. If
+    # you do not have any paths like that, then you might prefer to use a
+    # laxer rule, such as:
+    #   location ~ \.php(/|$) {
+    # The laxer rule will continue to work if Drupal uses this new URL
+    # pattern with front controllers other than update.php in a future
+    # release.
+    location ~ \.php(/|$) {
+        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+        # Override host for health endpoint
+        if ($uri = "/index.php/health")  {
+            set $customhost drupal;
+        }
+        fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param HTTP_HOST $customhost;
+        # make drupal understand clients were talking https to the loadbalancer
+        fastcgi_param HTTPS on;
+        fastcgi_param HTTP_SCHEME https;
+        fastcgi_intercept_errors on;
+        # changed from drupal-fpm to localhost for azure containers
+        fastcgi_pass localhost:9000;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+        try_files $uri @rewrite;
+        expires max;
+        log_not_found off;
+    }
+
+    # Fighting with Styles? This little gem is amazing.
+    # location ~ ^/sites/.*/files/imagecache/ { # For Drupal <= 6
+    location ~ ^/sites/.*/files/styles/ { # For Drupal >= 7
+        try_files $uri @rewrite;
+    }
+
+    # Handle private files through Drupal. Private file's path can come
+    # with a language prefix.
+    location ~ ^(/[a-z\-]+)?/system/files/ { # For Drupal >= 7
+        try_files $uri /index.php?$query_string;
+    }
+
+    rewrite '^(/News/.*)$' https://$customhost/news permanent;
+    rewrite '^(/Activities/.*)$' https://$customhost/leisure-culture-local-heritage permanent;
+    rewrite '^(/Publications/.*)$' https://$customhost/ permanent;
+    rewrite '^(/privacy-notices/.*)$' https://$customhost/topic/privacy-and-data-protection permanent;
+    rewrite '^(/customer-services/.*)$' https://$customhost/topic/contact-us permanent;
+    rewrite '^(/Libraries-Archives/.*)$' https://$customhost/essex-libraries permanent;
+    rewrite '^(/Your-Council/Pages/.*)$' https://$customhost/topic/running-the-council permanent;
+    rewrite '^(/enforcement-policy/.*)$' https://$customhost/trading-standards-policies-and-procedures/trading-standards-enforcement-policy permanent;
+    rewrite '^(/Transport and Roads/.*)$' https://$customhost/roads-streets-and-transport permanent;
+    rewrite '^(/Business-Partners/Pages/.*)$' https://$customhost/topic/business permanent;
+    rewrite '^(/Education-Schools/Pages/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Births Ceremonies Deaths/.*)$' https://$customhost/topic/births-ceremonies-deaths permanent;
+    rewrite '^(/Your-Council/Councillors/.*)$' https://$customhost/your-councillor permanent;
+    rewrite '^(/Health-Social-Care/Health/.*)$' https://$customhost/topic/adult-social-care-and-health permanent;
+    rewrite '^(/Business-Partners/Partners/.*)$' https://$customhost/topic/business permanent;
+    rewrite '^(/Business-Partners/licences/.*)$' https://$customhost/topic/licences permanent;
+    rewrite '^(/Community-Safety/Communities/.*)$' https://$customhost/leisure-culture-local-heritage permanent;
+    rewrite '^(/Your-Council/Your-Right-Know/.*)$' https://$customhost/request-information permanent;
+    rewrite '^(/Education-Schools/Schools/Dates/.*)$' https://$customhost/school-terms-and-holidays permanent;
+    rewrite '^(/Education-Schools/Travel-School/.*)$' https://$customhost/school-transport permanent;
+    rewrite '^(/Environment Planning/Environment/.*)$' https://$customhost/topic/planning-land-recycling permanent;
+    rewrite '^(/Health-Social-Care/Care-Children/.*)$' https://$customhost/topic/children-young-people-and-families permanent;
+    rewrite '^(/Your-Council/Strategies-Policies/.*)$' https://$customhost/topic/running-the-council permanent;
+    rewrite '^(/Business-Partners/Traded_Services/.*)$' https://$customhost/services-we-sell permanent;
+    rewrite '^(/Education-Schools/Apprenticeships/.*)$' https://$customhost/jobs-volunteering-apprenticeships/apprenticeships permanent;
+    rewrite '^(/Education-Schools/Post-16-options/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Education-Schools/Schools/Learning/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Your-Council/Consultation-Feedback/.*)$' https://$customhost/get-involved permanent;
+    rewrite '^(/Business-Partners/Supplying-Council/.*)$' https://$customhost/supply-the-council permanent;
+    rewrite '^(/Your-Council/Local-Government-Essex/.*)$' https://$customhost/topic/running-the-council permanent;
+    rewrite '^(/business-advice-and-charging-policy/.*)$' https://$customhost/trading-standards-policies-and-procedures/trading-standards-business-advice-and-charging-policy permanent;
+    rewrite '^(/Education-Schools/Schools/Admissions/.*)$' https://$customhost/topic/admissions permanent;
+    rewrite '^(/Environment Planning/Recycling-Waste/.*)$' https://$customhost/waste-recycling permanent;
+    rewrite '^(/Education-Schools/Early-Years-Childcare/.*)$' https://$customhost/topic/early-years-and-childcare permanent;
+    rewrite '^(/Your-Council/Committees-Decision-Making/.*)$' https://$customhost/how-decisions-are-made permanent;
+    rewrite '^(/Business-Partners/Business-Advice-Support/.*)$' https://$customhost/support-for-businesses permanent;
+    rewrite '^(/Education-Schools/Schools/Work-Experience/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Environment Planning/Development-in-Essex/.*)$' https://$customhost/topic/planning-development permanent;
+    rewrite '^(/Your-Council/Council-Spending/council-tax/.*)$' https://$customhost/spending-and-council-tax permanent;
+    rewrite '^(/Education-Schools/Schools/Attending-School/.*)$' https://$customhost/school-attendance-and-absence permanent;
+    rewrite '^(/Environment Planning/Strategic-Environment/.*)$' https://$customhost/topic/planning-land-recycling permanent;
+    rewrite '^(/Education-Schools/Schools/Educational-builds/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Your-Council/Local-Government-Essex/Documents/.*)$' https://$customhost/how-decisions-are-made/how-decisions-are-made permanent;
+    rewrite '^(/Business-Partners/Trading-Standards/businesses/.*)$' https://$customhost/trading-standards-for-businesses permanent;
+    rewrite '^(/Education-Schools/Schools/Pupil-Parent-Support/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Your-Council/Council-Spending/council-contracts/.*)$' https://$customhost/spending-and-council-tax/finance-and-spending-breakdowns permanent;
+    rewrite '^(/Community-Safety/Trading-Standards-for-Consumers/.*)$' https://$customhost/trading-standards-for-consumers permanent;
+    rewrite '^(/Education-Schools/Schools/Special-Education-Needs/.*)$' https://$customhost/special-educational-needs-and-disabilities permanent;
+    rewrite '^(/Environment Planning/Minerals-Waste-Planning-Team/.*)$' https://$customhost/topic/planning-development permanent;
+    rewrite '^(/Education-Schools/Schools/Discipline-and-Exclusion/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Your-Council/Strategies-Policies/Code-of-Governance/.*)$' https://$customhost/governance permanent;
+    rewrite '^(/Education-Schools/Schools/Delivering-Education-Essex/.*)$' https://$customhost/topic/schools-and-learning permanent;
+    rewrite '^(/Education-Schools/Schools/becoming-a-school-governor/.*)$' https://$customhost/school-governors permanent;
+    rewrite '^(/Your-Council/Councillors/Allowances/Documents/Report/.*)$' https://$customhost/governance permanent;
+    rewrite '^(/Business-Partners/Partners/Community-initiatives-fund/.*)$' https://$customhost/leisure-culture-local-heritage/culture-and-communities permanent;
+    rewrite '^(/Health-Social-Care/Families-and-childrens-social-care/.*)$' https://$customhost/topic/children-young-people-and-families permanent;
+    rewrite '^(/Education-Schools/Early-Years-Childcare/Find-a-provider/.*)$' https://$customhost/find-a-childcare-provider permanent;
+    rewrite '^(/Environment Planning/Environment/local-environment/Pages/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
+    rewrite '^(/Education-Schools/Schools/Admissions/Catchment_Area_Checker/.*)$' https://$customhost/find-a-school permanent;
+    rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/Blue-Badges/.*)$' https://$customhost/blue-badge permanent;
+    rewrite '^(/Your-Council/Local-Government-Essex/ECC-Structure/Senior-Officers/.*)$' https://$customhost/senior-officers permanent;
+    rewrite '^(/Environment Planning/Environment/local-environment/Trees and hedges/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
+    rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/Blue-Badges-Old/.*)$' https://$customhost/blue-badge permanent;
+    rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/budgets-payments/.*)$' https://$customhost/personal-budgets-and-direct-payments permanent;
+    rewrite '^(/Environment Planning/Environment/local-environment/Gypsy-Traveller-Services/.*)$' https://$customhost/gypsies-travellers permanent;
+    rewrite '^(/Environment Planning/Environment/local-environment/Wildlife-and-Biodiversity/.*)$' https://$customhost/topic/trees-greens-woodland-wildlife permanent;
+    rewrite '^(/Health-Social-Care/Health-and-social-care-for-adults/charging-for-care-services/.*)$' https://$customhost/topic/paying-for-care-and-support permanent;
+    rewrite '^(/Health-Social-Care/Families-and-childrens-social-care/Protecting-Vulnerable-Children/.*)$' https://$customhost/report-a-concern-about-a-child permanent;
+    rewrite '^(/topic/adult-social-care-and-health/redirect/.*)$' https://$customhost/topic/adult-social-care-and-health permanent;
 }


### PR DESCRIPTION
Instead of using URL rewriting to add noindex, make it a container option. This is less flexible, but works reliably. The previous method couldn't be used in any circumstances that required further rewrites or conditionals.

This moves the overwritten nginx config file to a default site, using template environment variable interpolation. It also brings in the latest nginx version, upgrading from 1.22.1 to 1.23.4 at the time of writing.