### PR TITLE
ECCW-547: Use console logs

### DIFF
--- a/Dockerfile-drupal
+++ b/Dockerfile-drupal
@@ -86,6 +86,8 @@ WORKDIR /drupal
 
 RUN sed -i 's;listen = /run/php/php8.1-fpm.sock;listen = 9000;' /etc/php/8.1/fpm/pool.d/www.conf
 RUN echo "clear_env = no" >> /etc/php/8.1/fpm/pool.d/www.conf
+RUN sed -i 's/;catch_workers_output/catch_workers_output/' /etc/php/8.1/fpm/pool.d/www.conf
+RUN sed -i 's/;decorate_workers_output/decorate_workers_output/' /etc/php/8.1/fpm/pool.d/www.conf
 RUN echo 'extension="memcached.so"' >> /etc/php/8.1/fpm/conf.d/20-memcached.ini
 RUN sed -i 's;expose_php = on;expose_php = off;' /etc/php/8.1/fpm/php.ini && mkdir -p /run/php
 RUN sed -i 's;memory_limit = 128M;memory_limit = 384M;' /etc/php/8.1/fpm/php.ini


### PR DESCRIPTION
PHP FPM wasn't configured to pass logs through from workers, enable this without the decoration.