### PR TITLE
ECCW-529: Add limited beta mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,6 +222,8 @@ deploy-to-preprod:
               env:
               - name: X_ROBOTS_TAG
                 value: noindex
+              - name: LIMITED_BETA_MODE
+                value: 1
             - image: acreccukspre.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG}
               name: drupal
               resources:
@@ -295,6 +297,8 @@ deploy-to-prod:
               env:
               - name: X_ROBOTS_TAG
                 value: noindex
+              - name: LIMITED_BETA_MODE
+                value: 1
             - image: acreccuksprod.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG}
               name: drupal
               resources:

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,5 +1,6 @@
 FROM nginx
 
 ENV X_ROBOTS_TAG="none"
+ENV LIMITED_BETA_MODE="0"
 COPY --chown=www-data:www-data --from=portal-drupal-fpm /drupal /drupal
 COPY nginx-conf/nginx.conf /etc/nginx/templates/default.conf.template

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -92,6 +92,48 @@ server {
     # release.
     location ~ \.php(/|$) {
         add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+
+        set $access_denied ${LIMITED_BETA_MODE};
+        if ($request_uri ~ /births-ceremonies-and-deaths/get-married-or-form-civil-partnership) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /form/feedback-form) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /cookies) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /adult-social-care-and-health/blue-badge) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /user) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /dd822309-ae33-4e29-addf-869b07453a06) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /node) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /media) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /core) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /modules) {
+            set $access_denied 0;
+        }
+        if ($request_uri ~ /themes) {
+            set $access_denied 0;
+        }
+        if ($http_cookie ~* "SESS" ) {
+            set $access_denied 0;
+        }
+        if ($access_denied) {
+            return 302 https://www.essex.gov.uk/;
+        }
+
         # Override host for health endpoint
         if ($uri = "/index.php/health")  {
             set $customhost drupal;


### PR DESCRIPTION
This mode is set by an environment variable, currently only active in preprod and prod, which redirects all requests handled by the Drupal backend to the current essex homepage if they don't match a URL whitelist OR there's no session cookie set.