### PR TITLE
ECCW-527: Add missing visit-us url

### DIFF
--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -109,6 +109,9 @@ server {
         if ($request_uri ~ /user) {
             set $access_denied 0;
         }
+        if ($request_uri ~ /visit-us) {
+            set $access_denied 0;
+        }
         if ($request_uri ~ /dd822309-ae33-4e29-addf-869b07453a06) {
             set $access_denied 0;
         }


### PR DESCRIPTION
This adds a URL that was missing from the original config that shouldn't be redirected.