### PR TITLE
ECCW-519: Adds z-index to drupal editor menu

### DIFF
--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -1132,3 +1132,8 @@ nav.lgd-prev-next ul.lgd-prev-next__list li {
 nav ul li a {
   display: block;
 }
+
+/* Drupal editor toolbar */
+#toolbar-administration * {
+  z-index: 99999;
+}


### PR DESCRIPTION
Adds z-index to drupal editor menu to make it appear above the cookie banner