### PR TITLE
ECCW-575: Fix large file upload

### DIFF
--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -5,6 +5,7 @@ server {
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;
+    client_max_body_size 120M;
 
     location = /favicon.ico {
         log_not_found off;


### PR DESCRIPTION
Re-add the client max body size that was accidentally removed when switching to templated nginx config, rather than replacing the root config.