### PR TITLE
ECCW-589: Block search engines from indexing documents.

### DIFF
--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -160,7 +160,7 @@ server {
 
     # Scripts/styles/images
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+        add_header X-Robots-Tag "noindex" always;
         try_files $uri @rewrite;
         expires max;
         log_not_found off;
@@ -168,7 +168,7 @@ server {
 
     # Documents
     location ~* \.(pdf|(xls|doc|pp[st])[xm]?|txt|rtf|csv|key|7z|rar|gz|zip)$ {
-        add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
+        add_header X-Robots-Tag "noindex" always;
         try_files $uri @rewrite;
         expires max;
         log_not_found off;


### PR DESCRIPTION
Logic is same as that for scripts/styles/images but added separately for legibility.