### PR TITLE
ECCW-604: Enable caching

### DIFF
--- a/config/default/system.performance.yml
+++ b/config/default/system.performance.yml
@@ -2,9 +2,9 @@ _core:
   default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
-    max_age: 0
+    max_age: 180
 css:
-  preprocess: false
+  preprocess: true
   gzip: true
 fast_404:
   enabled: true
@@ -12,6 +12,6 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: false
+  preprocess: true
   gzip: true
 stale_file_threshold: 2592000


### PR DESCRIPTION
Enable caching in the config, after testing directly for the last few weeks. This enables pre-processing of CSS and JS, and sets a max-age of 3 minutes as there's no active cache-clearing in AFD.