### PR TITLE
ECCW-599: Redirect if CANONICAL_HOST env is set and does not match cu…

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -18,6 +18,17 @@ server {
     error_log /dev/stdout info;
     access_log /var/log/nginx/access.log;
 
+    # The strange logic here replicates the lines in nginx-conf/nginx.conf.
+    # Environment variables set in DDEV config.yaml are not available here,
+    # so a fixed value is used.
+    set $canonical_host 'essex-public.ddev.site';
+    if ($canonical_host = false) {
+        set $canonical_host $host;
+    }
+    if ($host != $canonical_host) {
+        return 302 https://$canonical_host$request_uri;
+    }
+
     location / {
         absolute_redirect off;
         try_files $uri $uri/ /index.php?$query_string; # For Drupal >= 7
@@ -36,6 +47,8 @@ server {
 
     # pass the PHP scripts to FastCGI server listening on socket
     location ~ '\.php$|^/update.php' {
+        add_header Link '< href=https://essex-public.ddev.site$request_uri >; rel=\"canonical\"';
+
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/run/php-fpm.sock;
         fastcgi_buffers 16 16k;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,8 @@ deploy-to-dev:
               env:
               - name: X_ROBOTS_TAG
                 value: noindex
+              - name: CANONICAL_HOST
+                value: essex-gov.nomensa.xyz
               probes:
               - type: liveness
                 httpGet:
@@ -194,6 +196,8 @@ deploy-to-preprod:
               env:
               - name: X_ROBOTS_TAG
                 value: noindex
+              - name: CANONICAL_HOST
+                value: essex-gov-pp.nomensa.xyz
               - name: LIMITED_BETA_MODE
                 value: 0
               probes:
@@ -293,6 +297,8 @@ deploy-to-prod:
                 value: all
               - name: LIMITED_BETA_MODE
                 value: 0
+              - name: CANONICAL_HOST
+                value: beta.essex.gov.uk
               probes:
               - type: liveness
                 httpGet:

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -7,6 +7,16 @@ server {
     error_log /var/log/nginx/error.log;
     client_max_body_size 120M;
 
+    # If CANONICAL_HOST is set and does not match the current host then
+    # redirect to the canonical url.
+    set $canonical_host ${CANONICAL_HOST};
+    if ($canonical_host = false) {
+        set $canonical_host $host;
+    }
+    if ($host != $canonical_host) {
+        return 302 https://$canonical_host$request_uri;
+    }
+
     location = /favicon.ico {
         log_not_found off;
         access_log off;
@@ -92,6 +102,7 @@ server {
     # pattern with front controllers other than update.php in a future
     # release.
     location ~ \.php(/|$) {
+        add_header Link '< href=https://${CANONICAL_HOST}/$request_uri >; rel=\"canonical\"';
         add_header X-Robots-Tag "${X_ROBOTS_TAG}" always;
 
         set $access_denied ${LIMITED_BETA_MODE};


### PR DESCRIPTION
ECCW-599: 
- Redirect if CANONICAL_HOST env is set and does not match current host. 
- Add canonical link to header.