### PR TITLE
Fix redirect logic when no canonical set

### DIFF
--- a/.ddev/nginx_full/nginx-site.conf
+++ b/.ddev/nginx_full/nginx-site.conf
@@ -22,7 +22,7 @@ server {
     # Environment variables set in DDEV config.yaml are not available here,
     # so a fixed value is used.
     set $canonical_host 'essex-public.ddev.site';
-    if ($canonical_host = false) {
+    if ($canonical_host = '') {
         set $canonical_host $host;
     }
     if ($host != $canonical_host) {

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -18,8 +18,8 @@ server {
 
     # If CANONICAL_HOST is set and does not match the current host then
     # redirect to the canonical url.
-    set $canonical_host ${CANONICAL_HOST};
-    if ($canonical_host = false) {
+    set $canonical_host '${CANONICAL_HOST}';
+    if ($canonical_host = '') {
         set $canonical_host $customhost;
     }
     if ($customhost != $canonical_host) {


### PR DESCRIPTION
If there's no canonical URL set in the environment, then we're looking for an empty string. Similarly, the variable should be contained within a string while interpolating.