### PR TITLE
Expose the latest release as the release tag in ACR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,15 @@ build-and-push-images:
     - docker pull ${DOCKER_REGISTRY}/portal-nginx-drupal || true
     - docker pull ${DOCKER_REGISTRY}/portal-drupal-fpm || true
     - docker pull ${DOCKER_REGISTRY}/portal-nginx-redirect || true
-    - docker build -t ${DOCKER_REGISTRY}/portal-drupal-fpm${tag} -t portal-drupal-fpm -f Dockerfile-drupal .
-    - docker build -t ${DOCKER_REGISTRY}/portal-nginx-drupal${tag} -t portal-nginx-drupal -f Dockerfile-nginx .
-    - docker build -t ${DOCKER_REGISTRY}/portal-nginx-redirect${tag} -t portal-nginx-redirect -f Dockerfile-nginx-redirect .
+    - docker build -t ${DOCKER_REGISTRY}/portal-drupal-fpm -t ${DOCKER_REGISTRY}/portal-drupal-fpm${tag} -t portal-drupal-fpm -f Dockerfile-drupal .
+    - docker build -t ${DOCKER_REGISTRY}/portal-nginx-drupal -t ${DOCKER_REGISTRY}/portal-nginx-drupal${tag} -t portal-nginx-drupal -f Dockerfile-nginx .
+    - docker build -t ${DOCKER_REGISTRY}/portal-nginx-redirect -t ${DOCKER_REGISTRY}/portal-nginx-redirect${tag} -t portal-nginx-redirect -f Dockerfile-nginx-redirect .
     - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal${tag}
+    - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal
     - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm${tag}
+    - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm
     - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect${tag}
+    - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect
   only:
     - develop
     - /^release\//
@@ -167,8 +170,11 @@ deploy-to-preprod:
   script:
     - echo "Importing image from Development  into Pre-Production"
     - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:latest --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --image portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --image portal-drupal-fpm:latest --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --image portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --image portal-nginx-redirect:latest --subscription "Essex County Council (Common)"
     - |
       cat > revision.yml <<EOF
       properties:
@@ -265,8 +271,11 @@ deploy-to-prod:
   script:
     - echo "Importing image from Pre-Production into Production"
     - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:latest --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --image portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-drupal-fpm:${CI_COMMIT_REF_SLUG} --image portal-drupal-fpm:latest --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --image portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
+    - az acr import --force --name acreccuksprod --source acreccukspre.azurecr.io/portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --image portal-nginx-redirect:latest --subscription "Essex County Council (Common)"
     - echo "Creating new revision of Container App"
     - |
       cat > revision.yml <<EOF


### PR DESCRIPTION
We've been pushing releases just as their release tag name, not updating the `latest` tag. We will continue to reference releases by their specific tag for deployments, but keeping `latest` up-to-date will assist with documenting maintenance commands.