### PR TITLE
ECCW-638: Updates page builder contact component styles

### DIFF
--- a/themes/custom/essex/css/overrides.css
+++ b/themes/custom/essex/css/overrides.css
@@ -514,13 +514,16 @@ h1:after,
 /* Contact Component */
 
 .paragraph--type--localgov-contact {
-  margin: 1em 0;
-  padding: 0.2em 0 0.2em 2em;
-  border-left: 8px solid var(--color-grey-light);
+  background: #f5f5f5;
+  border-left: 12px solid #dee0e2;
+  padding: 0.5rem 7.5px 0.5rem 1.5rem;
+  margin-bottom: 1.625rem;
+  line-height: 1.625rem;
+  font-size: 18px;
 }
 
 .paragraph--type--localgov-contact .field {
-  margin: 0.35em 0;
+  margin: var(--spacing) 0;
 }
 
 .paragraph--type--localgov-contact .field--name-localgov-contact-heading {


### PR DESCRIPTION
Contact component styles need to match the "inset" styles used on the WYSIWYG (https://www.essex.gov.uk/adult-social-care-and-health/get-social-care-help)

Styles copied over and tweaked slightly to make the components match.