### PR TITLE
Add Nomensa to CODEOWNERS for deployment jobs and allow 0-touch development deployments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Nomensa approvals for deployment support
+.gitlab-ci.yml  @essexcountycouncil/nomensa
+Dockerfile*     @essexcountycouncil/nomensa
+deploy.sh       @essexcountycouncil/nomensa

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,9 +183,7 @@ deploy-to-dev:
     - az containerapp revision copy --name portal --resource-group rg-ecc-portal-uks-dev --yaml revision.yml --subscription "Essex County Council (Portal)"
   rules:
     - if: '$CI_COMMIT_BRANCH == "develop"'
-      when: manual
     - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: manual
 
 drush-deploy-dev:
   image: mcr.microsoft.com/azure-cli
@@ -200,9 +198,7 @@ drush-deploy-dev:
     - timeout 1200 socat EXEC:'az containerapp exec --command /drupal/deploy.sh --name portal --container drupal --resource-group rg-ecc-portal-uks-dev',pty,setsid,ctty STDIO,ignoreeof
   rules:
     - if: '$CI_COMMIT_BRANCH == "develop"'
-      when: manual
     - if: '$CI_COMMIT_BRANCH =~ /^release\//'
-      when: manual
 
 deploy-to-preprod:
   image: mcr.microsoft.com/azure-cli


### PR DESCRIPTION
This change adds the Nomensa team as code owners for files critical to deployments, to ensure that any changes are reviewed by a SME prior to pushing to development environments.

It also removes the manual gate on development deployments, so any merged PR will trigger a deployment.