### PR TITLE
ECCW-663: LP-18: Set permissions for editors to edit subsites

### DIFF
--- a/config/default/user.role.localgov_editor.yml
+++ b/config/default/user.role.localgov_editor.yml
@@ -133,6 +133,8 @@ permissions:
   - 'delete any localgov_services_sublanding content'
   - 'delete any localgov_step_by_step_overview content'
   - 'delete any localgov_step_by_step_page content'
+  - 'delete any localgov_subsites_overview content'
+  - 'delete any localgov_subsites_page content'
   - 'delete any media'
   - 'delete any remote_video media'
   - 'delete content owner/sme entity'


### PR DESCRIPTION
ECCW-663: LP-18: Set permissions for editors to edit subsite overview and subsite page content types

Most permissions requested by Will Callaghan had been set already by the Config Alignment work but this has not been deployed yet to Preprod and Prod