### PR TITLE
ECCW-664: Set Automatic Cron to run every 900 seconds

### DIFF
--- a/config/default/automated_cron.settings.yml
+++ b/config/default/automated_cron.settings.yml
@@ -1,3 +1,3 @@
 _core:
   default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs
-interval: 0
+interval: 900


### PR DESCRIPTION
ECCI-439 stopped Cron running automatically. Set it to run every 900 seconds (15 minutes.)