### PR TITLE
Feature/content access control from main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ certs/
 
 # Ignore config which may contain secrets
 .ddev/.env
+.docksal

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
         "essexcountycouncil/content_ownership": "dev-main",
         "localgovdrupal/localgov": "^2.0",
         "localgovdrupal/localgov_base": "^1.4",
+        "localgovdrupal/localgov_content_access_control": "^1",
         "localgovdrupal/localgov_eu_cookie_compliance": "1.x-dev",
         "localgovdrupal/localgov_forms": "1.x-dev",
         "localgovdrupal/localgov_geo": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "049fb1abadb1322e267b0ea24791e5fc",
+    "content-hash": "088e0aa5f96c2e8645db04406a04f46c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7347,6 +7347,134 @@
             }
         },
         {
+            "name": "drupal/workbench",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/workbench.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/workbench-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "bec38d8c333c1b72402f2e66be29838b65235fcd"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1666723245",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "agentrickard",
+                    "homepage": "https://www.drupal.org/user/20975"
+                },
+                {
+                    "name": "bbinkovitz",
+                    "homepage": "https://www.drupal.org/user/161263"
+                },
+                {
+                    "name": "becw",
+                    "homepage": "https://www.drupal.org/user/81067"
+                },
+                {
+                    "name": "caroltron",
+                    "homepage": "https://www.drupal.org/user/171342"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "robeano",
+                    "homepage": "https://www.drupal.org/user/67660"
+                },
+                {
+                    "name": "stevector",
+                    "homepage": "https://www.drupal.org/user/179805"
+                }
+            ],
+            "description": "Provides convenient dashboards and shortcuts for editors.",
+            "homepage": "https://www.drupal.org/project/workbench",
+            "support": {
+                "source": "https://git.drupalcode.org/project/workbench"
+            }
+        },
+        {
+            "name": "drupal/workbench_access",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/workbench_access.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/workbench_access-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "112dc52da87c23c61aee9bcb7329f35d59e6fa11"
+            },
+            "require": {
+                "drupal/core": "^9 || ^10"
+            },
+            "require-dev": {
+                "drupal/inline_entity_form": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1676497401",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "agentrickard",
+                    "homepage": "https://www.drupal.org/user/20975"
+                },
+                {
+                    "name": "becw",
+                    "homepage": "https://www.drupal.org/user/81067"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Hierarchical access control for content.",
+            "homepage": "https://www.drupal.org/project/workbench_access",
+            "support": {
+                "source": "https://git.drupalcode.org/project/workbench_access"
+            }
+        },
+        {
             "name": "drush/drush",
             "version": "11.6.0",
             "source": {
@@ -8845,6 +8973,37 @@
                 "source": "https://github.com/localgovdrupal/localgov_base/tree/1.4.13"
             },
             "time": "2023-09-04T13:33:33+00:00"
+        },
+        {
+            "name": "localgovdrupal/localgov_content_access_control",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localgovdrupal/localgov_content_access_control.git",
+                "reference": "04e7e5b291f11fcc73689af4ac11294b21fea99f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_content_access_control/zipball/04e7e5b291f11fcc73689af4ac11294b21fea99f",
+                "reference": "04e7e5b291f11fcc73689af4ac11294b21fea99f",
+                "shasum": ""
+            },
+            "require": {
+                "drupal/workbench": "^1.4",
+                "drupal/workbench_access": "^2.0"
+            },
+            "type": "drupal-module",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates access control mechanisms so specific editors can only edit specific sections of the website.",
+            "homepage": "https://github.com/localgovdrupal/localgov_content_access_control",
+            "support": {
+                "issues": "https://github.com/localgovdrupal/localgov_content_access_control/issues",
+                "source": "https://github.com/localgovdrupal/localgov_content_access_control/tree/1.0.0"
+            },
+            "time": "2023-11-03T12:56:17+00:00"
         },
         {
             "name": "localgovdrupal/localgov_core",
@@ -20250,5 +20409,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/default/core.entity_form_display.node.localgov_directories_org.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_directories_org.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_form_mode.localgov_geo.inline
     - field.field.node.localgov_directories_org.body
+    - field.field.node.localgov_directories_org.localgov_access_control
     - field.field.node.localgov_directories_org.localgov_directory_channels
     - field.field.node.localgov_directories_org.localgov_directory_email
     - field.field.node.localgov_directories_org.localgov_directory_facets_select
@@ -14,11 +15,14 @@ dependencies:
     - field.field.node.localgov_directories_org.localgov_directory_website
     - field.field.node.localgov_directories_org.localgov_location
     - node.type.localgov_directories_org
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
     - field_group
     - inline_entity_form
     - link
     - localgov_directories
+    - localgov_review_date
     - media_library
     - path
     - telephone
@@ -128,6 +132,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_directory_channels:
     type: localgov_directories_channel_selector
     weight: 9
@@ -191,6 +205,18 @@ content:
       collapsed: false
       revision: false
     third_party_settings: {  }
+  localgov_review_date:
+    type: review_date
+    weight: -5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 5
@@ -203,6 +229,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
@@ -235,5 +266,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.node.localgov_directories_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_directories_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -15,11 +16,14 @@ dependencies:
     - field.field.node.localgov_directories_page.localgov_directory_title_sort
     - field.field.node.localgov_directories_page.localgov_directory_website
     - node.type.localgov_directories_page
+    - workflows.workflow.localgov_editorial
   module:
     - address
+    - content_moderation
     - field_group
     - link
     - localgov_directories
+    - localgov_review_date
     - media_library
     - path
     - telephone
@@ -117,6 +121,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_directory_address:
     type: address_default
     weight: 15
@@ -189,6 +203,18 @@ content:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
+  localgov_review_date:
+    type: review_date
+    weight: -5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 5
@@ -201,6 +227,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
@@ -233,5 +264,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.node.localgov_directories_venue.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_directories_venue.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - entity_browser.browser.localgov_geo_library
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -18,11 +19,14 @@ dependencies:
     - field.field.node.localgov_directories_venue.localgov_directory_website
     - field.field.node.localgov_directories_venue.localgov_location
     - node.type.localgov_directories_venue
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
     - entity_browser
     - field_group
     - link
     - localgov_directories
+    - localgov_review_date
     - media_library
     - path
     - telephone
@@ -133,6 +137,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_directory_channels:
     type: localgov_directories_channel_selector
     weight: 9
@@ -229,6 +243,18 @@ content:
       field_widget_display_settings: {  }
       selection_mode: selection_append
     third_party_settings: {  }
+  localgov_review_date:
+    type: review_date
+    weight: -5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 5
@@ -241,6 +267,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
@@ -273,5 +304,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.node.localgov_directory.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_directory.default.yml
@@ -4,11 +4,16 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
+    - localgov_review_date
     - path
     - text
 _core:
@@ -33,6 +38,16 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 124
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_directory_channel_types:
     type: options_buttons

--- a/config/default/core.entity_form_display.node.localgov_directory_promo_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_directory_promo_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directory_promo_page.body
+    - field.field.node.localgov_directory_promo_page.localgov_access_control
     - field.field.node.localgov_directory_promo_page.localgov_directory_address
     - field.field.node.localgov_directory_promo_page.localgov_directory_banner
     - field.field.node.localgov_directory_promo_page.localgov_directory_channels
@@ -129,6 +130,16 @@ content:
     weight: 10
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 121
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_directory_address:
     type: address_default

--- a/config/default/core.entity_form_display.node.localgov_event.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_event.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - entity_browser.browser.localgov_geo_library
     - field.field.node.localgov_event.body
+    - field.field.node.localgov_event.localgov_access_control
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
     - field.field.node.localgov_event.localgov_event_date
@@ -128,6 +129,16 @@ content:
     weight: 11
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_event_call_to_action:
     type: link_default

--- a/config/default/core.entity_form_display.node.localgov_guides_overview.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_guides_overview.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -78,6 +79,16 @@ content:
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   localgov_guides_description:

--- a/config/default/core.entity_form_display.node.localgov_guides_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_guides_page.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_page.body
     - field.field.node.localgov_guides_page.field_content_owner
     - field.field.node.localgov_guides_page.field_non_publishable_notes
+    - field.field.node.localgov_guides_page.localgov_access_control
     - field.field.node.localgov_guides_page.localgov_guides_parent
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - field.field.node.localgov_guides_page.localgov_page_components
@@ -73,6 +74,16 @@ content:
     region: content
     settings:
       rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   localgov_guides_parent:

--- a/config/default/core.entity_form_display.node.localgov_news_article.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_news_article.default.yml
@@ -5,14 +5,18 @@ dependencies:
   config:
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
+    - field.field.node.localgov_news_article.localgov_access_control
     - field.field.node.localgov_news_article.localgov_news_categories
     - field.field.node.localgov_news_article.localgov_news_date
     - field.field.node.localgov_news_article.localgov_news_related
     - field.field.node.localgov_news_article.localgov_newsroom
     - node.type.localgov_news_article
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
     - datetime
     - field_group
+    - localgov_review_date
     - media_library
     - path
     - text
@@ -125,6 +129,16 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_news_categories:
     type: entity_reference_autocomplete
     weight: 4
@@ -191,6 +205,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox

--- a/config/default/core.entity_form_display.node.localgov_newsroom.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_newsroom.default.yml
@@ -3,9 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_newsroom.localgov_access_control
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
     - node.type.localgov_newsroom
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
+    - localgov_review_date
     - path
   enforced:
     module:
@@ -23,6 +27,16 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_newsroom_featured:
     type: entity_reference_autocomplete
     weight: 1
@@ -32,6 +46,18 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  localgov_review_date:
+    type: review_date
+    weight: -5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
     third_party_settings: {  }
   path:
     type: path
@@ -45,6 +71,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
@@ -77,5 +108,10 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.node.localgov_services_landing.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_services_landing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -30,7 +31,7 @@ third_party_settings:
       label: Description
       region: hidden
       parent_name: ''
-      weight: 22
+      weight: 24
       format_type: tab
       format_settings:
         classes: ''
@@ -44,7 +45,7 @@ third_party_settings:
       label: 'Common tasks'
       region: hidden
       parent_name: ''
-      weight: 21
+      weight: 23
       format_type: tab
       format_settings:
         classes: ''
@@ -57,7 +58,7 @@ third_party_settings:
       label: 'Child pages'
       region: hidden
       parent_name: ''
-      weight: 17
+      weight: 19
       format_type: tab
       format_settings:
         classes: ''
@@ -71,7 +72,7 @@ third_party_settings:
       label: tabs
       region: hidden
       parent_name: ''
-      weight: 16
+      weight: 18
       format_type: tabs
       format_settings:
         classes: ''
@@ -84,7 +85,7 @@ third_party_settings:
       label: 'Social media'
       region: hidden
       parent_name: ''
-      weight: 19
+      weight: 21
       format_type: tab
       format_settings:
         classes: ''
@@ -98,7 +99,7 @@ third_party_settings:
       label: 'Popular topics'
       region: hidden
       parent_name: ''
-      weight: 18
+      weight: 20
       format_type: tab
       format_settings:
         classes: ''
@@ -114,7 +115,7 @@ third_party_settings:
       label: Location
       region: hidden
       parent_name: ''
-      weight: 20
+      weight: 22
       format_type: tab
       format_settings:
         classes: ''
@@ -167,6 +168,16 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 16
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_destinations:
     type: entity_reference_autocomplete
     weight: 5
@@ -206,7 +217,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -218,20 +229,20 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 14
+    weight: 15
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
@@ -255,7 +266,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/default/core.entity_form_display.node.localgov_services_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_services_page.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -31,7 +32,7 @@ third_party_settings:
       label: Content
       region: hidden
       parent_name: ''
-      weight: 16
+      weight: 18
       format_type: tab
       format_settings:
         classes: ''
@@ -45,7 +46,7 @@ third_party_settings:
       label: 'Task buttons'
       region: hidden
       parent_name: ''
-      weight: 19
+      weight: 21
       format_type: tab
       format_settings:
         classes: ''
@@ -62,7 +63,7 @@ third_party_settings:
       label: 'Related content'
       region: hidden
       parent_name: ''
-      weight: 17
+      weight: 19
       format_type: tab
       format_settings:
         classes: ''
@@ -75,7 +76,7 @@ third_party_settings:
       label: 'Content Ownership'
       region: hidden
       parent_name: ''
-      weight: 18
+      weight: 20
       format_type: tab
       format_settings:
         classes: ''
@@ -109,7 +110,7 @@ content:
     third_party_settings: {  }
   field_content_owner:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -119,15 +120,25 @@ content:
     third_party_settings: {  }
   field_non_publishable_notes:
     type: text_textarea
-    weight: 13
+    weight: 14
     region: content
     settings:
       rows: 3
       placeholder: ''
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 16
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_page_components:
     type: entity_browser_entity_reference
-    weight: 11
+    weight: 12
     region: content
     settings:
       entity_browser: page_components
@@ -157,7 +168,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -173,6 +184,11 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 11
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox

--- a/config/default/core.entity_form_display.node.localgov_services_status.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_services_status.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -39,6 +40,16 @@ content:
     weight: 3
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_review_date:
     type: review_date

--- a/config/default/core.entity_form_display.node.localgov_services_sublanding.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_services_sublanding.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -92,6 +93,16 @@ content:
     weight: 8
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_review_date:
     type: review_date

--- a/config/default/core.entity_form_display.node.localgov_step_by_step_overview.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_step_by_step_overview.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -37,6 +38,16 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 26
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_review_date:
     type: review_date

--- a/config/default/core.entity_form_display.node.localgov_step_by_step_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_step_by_step_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_step_by_step_page.body
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
     - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
@@ -36,6 +37,16 @@ content:
     weight: 7
     region: content
     settings: {  }
+    third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 101
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   localgov_review_date:
     type: review_date

--- a/config/default/core.entity_form_display.node.localgov_subsites_overview.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_subsites_overview.default.yml
@@ -3,15 +3,19 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_overview.localgov_access_control
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
     - field.field.node.localgov_subsites_overview.localgov_subsites_hide_menu
     - field.field.node.localgov_subsites_overview.localgov_subsites_summary
     - field.field.node.localgov_subsites_overview.localgov_subsites_theme
     - node.type.localgov_subsites_overview
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
     - field_group
     - layout_paragraphs
+    - localgov_review_date
     - paragraphs
     - path
 third_party_settings:
@@ -24,7 +28,7 @@ third_party_settings:
       label: tabs
       region: content
       parent_name: ''
-      weight: 0
+      weight: 1
       format_type: tabs
       format_settings:
         classes: ''
@@ -84,13 +88,23 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_review_date:
     type: review_date
-    weight: -5
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -114,6 +128,7 @@ content:
       preview_view_mode: default
       nesting_depth: 0
       require_layouts: 1
+      empty_message: ''
     third_party_settings: {  }
   localgov_subsites_hide_menu:
     type: boolean_checkbox
@@ -144,7 +159,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -162,13 +177,13 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 1
+    weight: 2
     region: content
     settings:
       display_label: true
@@ -190,7 +205,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/default/core.entity_form_display.node.localgov_subsites_page.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_subsites_page.default.yml
@@ -3,16 +3,20 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_page.localgov_access_control
     - field.field.node.localgov_subsites_page.localgov_subsites_banner
     - field.field.node.localgov_subsites_page.localgov_subsites_content
     - field.field.node.localgov_subsites_page.localgov_subsites_parent
     - field.field.node.localgov_subsites_page.localgov_subsites_summary
     - field.field.node.localgov_subsites_page.localgov_subsites_topic
     - node.type.localgov_subsites_page
+    - workflows.workflow.localgov_editorial
   module:
+    - content_moderation
     - entity_hierarchy
     - field_group
     - layout_paragraphs
+    - localgov_review_date
     - paragraphs
     - path
 third_party_settings:
@@ -25,7 +29,7 @@ third_party_settings:
       label: tabs
       region: content
       parent_name: ''
-      weight: 0
+      weight: 1
       format_type: tabs
       format_settings:
         classes: ''
@@ -89,9 +93,19 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_access_control:
+    type: entity_reference_autocomplete
+    weight: 11
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   localgov_review_date:
     type: review_date
-    weight: -5
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -115,6 +129,7 @@ content:
       preview_view_mode: default
       nesting_depth: 0
       require_layouts: 1
+      empty_message: ''
     third_party_settings: {  }
   localgov_subsites_parent:
     type: entity_reference_hierarchy_autocomplete
@@ -147,7 +162,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -165,7 +180,7 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -202,7 +217,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/default/core.entity_view_display.node.localgov_directories_org.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_org.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directories_org.body
+    - field.field.node.localgov_directories_org.localgov_access_control
     - field.field.node.localgov_directories_org.localgov_directory_channels
     - field.field.node.localgov_directories_org.localgov_directory_email
     - field.field.node.localgov_directories_org.localgov_directory_facets_select
@@ -23,15 +24,13 @@ third_party_settings:
   field_group:
     group_enquiries:
       children:
-        - localgov_directory_name
-        - localgov_directory_job_title
         - localgov_directory_phone
         - localgov_directory_email
         - localgov_directory_website
       label: Enquiries
       parent_name: ''
       region: content
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         classes: ''
@@ -40,12 +39,11 @@ third_party_settings:
     group_organisation:
       children:
         - localgov_location
-        - localgov_directory_opening_times
         - localgov_directory_notes
       label: Venue
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -63,6 +61,11 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 2
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
   localgov_directory_email:
@@ -78,7 +81,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
   localgov_directory_notes:
     type: text_default
@@ -98,7 +101,7 @@ content:
   localgov_directory_search:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 1
     region: content
   localgov_directory_website:
     type: link
@@ -123,6 +126,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_facets_select: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_directories_org.directory_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_org.directory_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.directory_index
     - field.field.node.localgov_directories_org.body
+    - field.field.node.localgov_directories_org.localgov_access_control
     - field.field.node.localgov_directories_org.localgov_directory_channels
     - field.field.node.localgov_directories_org.localgov_directory_email
     - field.field.node.localgov_directories_org.localgov_directory_facets_select
@@ -32,6 +33,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   links:
     settings: {  }
@@ -106,5 +112,6 @@ content:
     weight: 12
     region: content
 hidden:
+  localgov_access_control: true
   localgov_directory_search: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_directories_org.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_org.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directories_org.body
+    - field.field.node.localgov_directories_org.localgov_access_control
     - field.field.node.localgov_directories_org.localgov_directory_channels
     - field.field.node.localgov_directories_org.localgov_directory_email
     - field.field.node.localgov_directories_org.localgov_directory_facets_select
@@ -32,8 +33,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_email: true
   localgov_directory_facets_select: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
@@ -39,7 +39,7 @@ third_party_settings:
       label: Enquiries
       parent_name: ''
       region: content
-      weight: 3
+      weight: 2
       format_type: fieldset
       format_settings:
         classes: ''
@@ -55,11 +55,6 @@ content:
   body:
     type: text_default
     label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    weight: 1
-    region: content
-  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
     weight: 0
@@ -85,7 +80,7 @@ content:
       view_mode: default
       link: true
     third_party_settings: {  }
-    weight: 2
+    weight: 1
     region: content
   localgov_directory_job_title:
     type: string
@@ -124,6 +119,7 @@ content:
     weight: 8
     region: content
 hidden:
+  content_moderation_control: true
   links: true
   localgov_access_control: true
   localgov_directory_channels: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -38,7 +39,7 @@ third_party_settings:
       label: Enquiries
       parent_name: ''
       region: content
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -54,6 +55,11 @@ content:
   body:
     type: text_default
     label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
     weight: 0
@@ -79,7 +85,7 @@ content:
       view_mode: default
       link: true
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   localgov_directory_job_title:
     type: string
@@ -119,6 +125,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_facets_select: true
   localgov_directory_search: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.directory_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.directory_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.directory_index
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -37,6 +38,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_directory_address:
     type: address_default
@@ -114,6 +120,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_search: true
   localgov_directory_title_sort: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -38,6 +39,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_directory_address:
     type: address_default
@@ -113,6 +119,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_facets_select: true
   localgov_directory_title_sort: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -57,8 +58,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_address: true
   localgov_directory_channels: true
   localgov_directory_email: true

--- a/config/default/core.entity_view_display.node.localgov_directories_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directories_page.body
+    - field.field.node.localgov_directories_page.localgov_access_control
     - field.field.node.localgov_directories_page.localgov_directory_address
     - field.field.node.localgov_directories_page.localgov_directory_channels
     - field.field.node.localgov_directories_page.localgov_directory_email
@@ -34,8 +35,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_address: true
   localgov_directory_channels: true
   localgov_directory_email: true

--- a/config/default/core.entity_view_display.node.localgov_directories_venue.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_venue.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -35,7 +36,7 @@ third_party_settings:
       label: Enquiries
       parent_name: ''
       region: content
-      weight: 3
+      weight: 4
       format_type: fieldset
       format_settings:
         classes: ''
@@ -49,7 +50,7 @@ third_party_settings:
       label: Venue
       parent_name: ''
       region: content
-      weight: 2
+      weight: 3
       format_type: fieldset
       format_settings:
         classes: ''
@@ -67,6 +68,11 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
     weight: 0
     region: content
   localgov_directory_email:
@@ -82,7 +88,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   localgov_directory_job_title:
     type: string
@@ -145,6 +151,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_facets_select: true
   localgov_directory_search: true

--- a/config/default/core.entity_view_display.node.localgov_directories_venue.directory_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_venue.directory_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.directory_index
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -35,6 +36,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 1
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   links:
     settings: {  }
@@ -132,6 +138,7 @@ content:
     weight: 12
     region: content
 hidden:
+  localgov_access_control: true
   localgov_directory_search: true
   localgov_directory_title_sort: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_directories_venue.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_venue.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -36,6 +37,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_directory_channels:
     type: entity_reference_label
@@ -121,6 +127,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_facets_select: true
   localgov_directory_search: true
   localgov_directory_title_sort: true

--- a/config/default/core.entity_view_display.node.localgov_directories_venue.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_venue.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -69,6 +70,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_directory_email:
     type: basic_string
@@ -151,6 +157,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_facets_select: true
   localgov_directory_title_sort: true

--- a/config/default/core.entity_view_display.node.localgov_directories_venue.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_venue.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directories_venue.body
+    - field.field.node.localgov_directories_venue.localgov_access_control
     - field.field.node.localgov_directories_venue.localgov_directory_channels
     - field.field.node.localgov_directories_venue.localgov_directory_email
     - field.field.node.localgov_directories_venue.localgov_directory_facets_select
@@ -36,8 +37,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_email: true
   localgov_directory_facets_select: true

--- a/config/default/core.entity_view_display.node.localgov_directory.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory.default.yml
@@ -4,8 +4,10 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
   module:
@@ -23,25 +25,26 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
+    weight: 0
     region: content
   localgov_directory_map:
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 2
     region: content
   localgov_directory_view:
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 3
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_facets_enable: true

--- a/config/default/core.entity_view_display.node.localgov_directory.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory.grid_item.yml
@@ -5,8 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.node.grid_item
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
   module:
@@ -34,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_facets_enable: true

--- a/config/default/core.entity_view_display.node.localgov_directory.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory.search_index.yml
@@ -5,8 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
   module:
@@ -49,6 +51,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_map: true

--- a/config/default/core.entity_view_display.node.localgov_directory.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory.search_result.yml
@@ -5,8 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
   module:
@@ -34,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_facets_enable: true

--- a/config/default/core.entity_view_display.node.localgov_directory.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory.teaser.yml
@@ -5,8 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directory.body
+    - field.field.node.localgov_directory.localgov_access_control
     - field.field.node.localgov_directory.localgov_directory_channel_types
     - field.field.node.localgov_directory.localgov_directory_facets_enable
+    - field.field.node.localgov_directory.localgov_proximity_search_cfg
     - field.field.node.localgov_directory.localgov_services_parent
     - node.type.localgov_directory
   module:
@@ -34,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_channel_types: true
   localgov_directory_facets: true
   localgov_directory_facets_enable: true

--- a/config/default/core.entity_view_display.node.localgov_directory_promo_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory_promo_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_directory_promo_page.body
+    - field.field.node.localgov_directory_promo_page.localgov_access_control
     - field.field.node.localgov_directory_promo_page.localgov_directory_address
     - field.field.node.localgov_directory_promo_page.localgov_directory_banner
     - field.field.node.localgov_directory_promo_page.localgov_directory_channels
@@ -20,6 +21,7 @@ dependencies:
     - node.type.localgov_directory_promo_page
   module:
     - address
+    - entity_reference_revisions
     - field_formatter_class
     - field_group
     - layout_paragraphs
@@ -35,7 +37,7 @@ third_party_settings:
       label: Banner
       parent_name: ''
       region: content
-      weight: 0
+      weight: 1
       format_type: html_element
       format_settings:
         classes: full__banner
@@ -55,7 +57,7 @@ third_party_settings:
       label: 'Page Top'
       parent_name: ''
       region: content
-      weight: 1
+      weight: 2
       format_type: html_element
       format_settings:
         classes: full__page-top
@@ -79,7 +81,7 @@ third_party_settings:
       label: Enquiries
       parent_name: ''
       region: content
-      weight: 6
+      weight: 7
       format_type: fieldset
       format_settings:
         classes: ''
@@ -98,12 +100,17 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 2
+    weight: 3
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   localgov_directory_address:
     type: address_default
@@ -113,11 +120,11 @@ content:
     weight: 12
     region: content
   localgov_directory_banner:
-    type: entity_reference_entity_view
+    type: entity_reference_revisions_entity_view
     label: hidden
     settings:
       view_mode: responsive_banner
-      link: false
+      link: ''
     third_party_settings:
       field_formatter_class:
         class: ''
@@ -146,7 +153,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
   localgov_directory_job_title:
     type: string
@@ -196,11 +203,12 @@ content:
     label: hidden
     settings:
       view_mode: default
-      link: false
+      link: ''
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
 hidden:
+  localgov_access_control: true
   localgov_directory_channels: true
   localgov_directory_search: true
   localgov_directory_title_sort: true

--- a/config/default/core.entity_view_display.node.localgov_directory_promo_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_directory_promo_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_directory_promo_page.body
+    - field.field.node.localgov_directory_promo_page.localgov_access_control
     - field.field.node.localgov_directory_promo_page.localgov_directory_address
     - field.field.node.localgov_directory_promo_page.localgov_directory_banner
     - field.field.node.localgov_directory_promo_page.localgov_directory_channels
@@ -40,6 +41,11 @@ content:
     third_party_settings: {  }
     weight: 1
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   localgov_directory_banner:
     type: media_thumbnail
     label: hidden
@@ -55,6 +61,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_directory_address: true
   localgov_directory_channels: true
   localgov_directory_email: true

--- a/config/default/core.entity_view_display.node.localgov_event.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_event.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.date_format.localgov_event_date_full
     - core.date_format.localgov_event_date_hour
     - field.field.node.localgov_event.body
+    - field.field.node.localgov_event.localgov_access_control
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
     - field.field.node.localgov_event.localgov_event_date
@@ -33,7 +34,12 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 4
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
     region: content
   localgov_event_call_to_action:
     type: link
@@ -45,7 +51,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   localgov_event_date:
     type: date_recur_basic_formatter
@@ -60,7 +66,7 @@ content:
       same_end_date_format_type: localgov_event_date_hour
       interpreter: ''
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
   localgov_event_image:
     type: entity_reference_entity_view
@@ -69,7 +75,7 @@ content:
       view_mode: scale_crop_7_3_large
       link: false
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   localgov_event_location:
     type: entity_reference_entity_view
@@ -78,7 +84,7 @@ content:
       view_mode: embed
       link: false
     third_party_settings: {  }
-    weight: 6
+    weight: 7
     region: content
   localgov_event_provider:
     type: entity_reference_label
@@ -86,7 +92,7 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   localgov_event_venue:
     type: entity_reference_label
@@ -94,10 +100,11 @@ content:
     settings:
       link: true
     third_party_settings: {  }
-    weight: 5
+    weight: 6
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_event_categories: true
   localgov_event_locality: true
   localgov_event_price: true

--- a/config/default/core.entity_view_display.node.localgov_event.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_event.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_event.body
+    - field.field.node.localgov_event.localgov_access_control
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
     - field.field.node.localgov_event.localgov_event_date
@@ -32,8 +33,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_event_call_to_action: true
   localgov_event_categories: true
   localgov_event_date: true

--- a/config/default/core.entity_view_display.node.localgov_event.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_event.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - core.date_format.localgov_event_date_hour
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_event.body
+    - field.field.node.localgov_event.localgov_access_control
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
     - field.field.node.localgov_event.localgov_event_date
@@ -35,6 +36,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 3
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_event_call_to_action:
     type: link
@@ -99,6 +105,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_event_categories: true
   localgov_event_locality: true
   localgov_event_price: true

--- a/config/default/core.entity_view_display.node.localgov_event.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_event.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - core.date_format.localgov_event_date_hour
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_event.body
+    - field.field.node.localgov_event.localgov_access_control
     - field.field.node.localgov_event.localgov_event_call_to_action
     - field.field.node.localgov_event.localgov_event_categories
     - field.field.node.localgov_event.localgov_event_date
@@ -36,6 +37,11 @@ content:
     third_party_settings: {  }
     weight: 2
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   localgov_event_date:
     type: date_recur_basic_formatter
     label: hidden
@@ -62,6 +68,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_event_call_to_action: true
   localgov_event_categories: true
   localgov_event_locality: true

--- a/config/default/core.entity_view_display.node.localgov_guides_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -50,6 +51,7 @@ hidden:
   entitygroupfield: true
   field_content_owner: true
   field_non_publishable_notes: true
+  localgov_access_control: true
   localgov_guides_description: true
   localgov_guides_list_format: true
   localgov_guides_pages: true

--- a/config/default/core.entity_view_display.node.localgov_guides_overview.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.grid_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -42,6 +43,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_list_format: true
   localgov_guides_pages: true
   localgov_guides_section_title: true

--- a/config/default/core.entity_view_display.node.localgov_guides_overview.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -81,6 +82,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_list_format: true
   localgov_page_components: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_guides_overview.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -43,6 +44,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_description: true
   localgov_guides_list_format: true
   localgov_guides_pages: true

--- a/config/default/core.entity_view_display.node.localgov_guides_overview.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_overview.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_overview.body
     - field.field.node.localgov_guides_overview.field_content_owner
     - field.field.node.localgov_guides_overview.field_non_publishable_notes
+    - field.field.node.localgov_guides_overview.localgov_access_control
     - field.field.node.localgov_guides_overview.localgov_guides_description
     - field.field.node.localgov_guides_overview.localgov_guides_list_format
     - field.field.node.localgov_guides_overview.localgov_guides_pages
@@ -42,6 +43,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_description: true
   localgov_guides_list_format: true
   localgov_guides_pages: true

--- a/config/default/core.entity_view_display.node.localgov_guides_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_guides_page.body
     - field.field.node.localgov_guides_page.field_content_owner
     - field.field.node.localgov_guides_page.field_non_publishable_notes
+    - field.field.node.localgov_guides_page.localgov_access_control
     - field.field.node.localgov_guides_page.localgov_guides_parent
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - field.field.node.localgov_guides_page.localgov_page_components
@@ -46,6 +47,7 @@ hidden:
   entitygroupfield: true
   field_content_owner: true
   field_non_publishable_notes: true
+  localgov_access_control: true
   localgov_guides_parent: true
   localgov_guides_section_title: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_guides_page.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_page.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_page.body
     - field.field.node.localgov_guides_page.field_content_owner
     - field.field.node.localgov_guides_page.field_non_publishable_notes
+    - field.field.node.localgov_guides_page.localgov_access_control
     - field.field.node.localgov_guides_page.localgov_guides_parent
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - field.field.node.localgov_guides_page.localgov_page_components
@@ -54,5 +55,6 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_page_components: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_guides_page.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_page.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_page.body
     - field.field.node.localgov_guides_page.field_content_owner
     - field.field.node.localgov_guides_page.field_non_publishable_notes
+    - field.field.node.localgov_guides_page.localgov_access_control
     - field.field.node.localgov_guides_page.localgov_guides_parent
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - field.field.node.localgov_guides_page.localgov_page_components
@@ -39,6 +40,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_parent: true
   localgov_guides_section_title: true
   localgov_page_components: true

--- a/config/default/core.entity_view_display.node.localgov_guides_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_guides_page.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_guides_page.body
     - field.field.node.localgov_guides_page.field_content_owner
     - field.field.node.localgov_guides_page.field_non_publishable_notes
+    - field.field.node.localgov_guides_page.localgov_access_control
     - field.field.node.localgov_guides_page.localgov_guides_parent
     - field.field.node.localgov_guides_page.localgov_guides_section_title
     - field.field.node.localgov_guides_page.localgov_page_components
@@ -39,6 +40,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_guides_parent: true
   localgov_guides_section_title: true
   localgov_page_components: true

--- a/config/default/core.entity_view_display.node.localgov_news_article.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
+    - field.field.node.localgov_news_article.localgov_access_control
     - field.field.node.localgov_news_article.localgov_news_categories
     - field.field.node.localgov_news_article.localgov_news_date
     - field.field.node.localgov_news_article.localgov_news_related
@@ -68,6 +69,7 @@ content:
 hidden:
   content_moderation_control: true
   entitygroupfield: true
+  localgov_access_control: true
   localgov_news_categories: true
   localgov_newsroom: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_news_article.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.search_index.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
+    - field.field.node.localgov_news_article.localgov_access_control
     - field.field.node.localgov_news_article.localgov_news_categories
     - field.field.node.localgov_news_article.localgov_news_date
     - field.field.node.localgov_news_article.localgov_news_related
@@ -40,6 +41,7 @@ hidden:
   entitygroupfield: true
   field_media_image: true
   links: true
+  localgov_access_control: true
   localgov_news_categories: true
   localgov_news_date: true
   localgov_news_related: true

--- a/config/default/core.entity_view_display.node.localgov_news_article.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.search_result.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
+    - field.field.node.localgov_news_article.localgov_access_control
     - field.field.node.localgov_news_article.localgov_news_categories
     - field.field.node.localgov_news_article.localgov_news_date
     - field.field.node.localgov_news_article.localgov_news_related
@@ -40,6 +41,7 @@ hidden:
   entitygroupfield: true
   field_media_image: true
   links: true
+  localgov_access_control: true
   localgov_news_categories: true
   localgov_news_date: true
   localgov_news_related: true

--- a/config/default/core.entity_view_display.node.localgov_news_article.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_news_article.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
+    - field.field.node.localgov_news_article.localgov_access_control
     - field.field.node.localgov_news_article.localgov_news_categories
     - field.field.node.localgov_news_article.localgov_news_date
     - field.field.node.localgov_news_article.localgov_news_related
@@ -62,6 +63,7 @@ content:
 hidden:
   entitygroupfield: true
   links: true
+  localgov_access_control: true
   localgov_news_categories: true
   localgov_news_related: true
   localgov_newsroom: true

--- a/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_newsroom.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_newsroom.localgov_access_control
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
     - node.type.localgov_newsroom
   module:
@@ -39,5 +40,6 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  localgov_access_control: true
   localgov_newsroom_featured: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -109,5 +110,6 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.full.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -133,6 +134,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   localgov_contact_us_online: true
   localgov_other_team_contacts: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.grid_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -41,6 +42,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_address: true
   localgov_address_first_line: true
   localgov_common_tasks: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -114,5 +115,6 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -41,6 +42,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_address: true
   localgov_address_first_line: true
   localgov_common_tasks: true

--- a/config/default/core.entity_view_display.node.localgov_services_landing.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_landing.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_landing.body
     - field.field.node.localgov_services_landing.field_content_owner
     - field.field.node.localgov_services_landing.field_non_publishable_notes
+    - field.field.node.localgov_services_landing.localgov_access_control
     - field.field.node.localgov_services_landing.localgov_address
     - field.field.node.localgov_services_landing.localgov_address_first_line
     - field.field.node.localgov_services_landing.localgov_common_tasks
@@ -41,6 +42,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_address: true
   localgov_address_first_line: true
   localgov_common_tasks: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -47,6 +48,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.grid_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -40,6 +41,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -101,6 +102,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_hide_related_topics: true
   localgov_override_related_links: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.search_result.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -40,6 +41,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/config/default/core.entity_view_display.node.localgov_services_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_page.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.localgov_services_page.body
     - field.field.node.localgov_services_page.field_content_owner
     - field.field.node.localgov_services_page.field_non_publishable_notes
+    - field.field.node.localgov_services_page.localgov_access_control
     - field.field.node.localgov_services_page.localgov_common_tasks
     - field.field.node.localgov_services_page.localgov_download_links
     - field.field.node.localgov_services_page.localgov_hide_related_topics
@@ -40,6 +41,7 @@ hidden:
   field_content_owner: true
   field_non_publishable_notes: true
   links: true
+  localgov_access_control: true
   localgov_common_tasks: true
   localgov_download_links: true
   localgov_hide_related_topics: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -30,6 +31,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.grid_item.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.grid_item
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -40,6 +41,7 @@ content:
     weight: 1
     region: content
 hidden:
+  localgov_access_control: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.message.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.message.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.message
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -31,6 +32,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -47,6 +48,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true
   localgov_service_status_visibile: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -32,6 +33,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/config/default/core.entity_view_display.node.localgov_services_status.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_status.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_services_status.body
+    - field.field.node.localgov_services_status.localgov_access_control
     - field.field.node.localgov_services_status.localgov_service_status
     - field.field.node.localgov_services_status.localgov_service_status_on_landi
     - field.field.node.localgov_services_status.localgov_service_status_on_list
@@ -29,12 +30,18 @@ content:
     third_party_settings: {  }
     weight: 101
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 100
     region: content
 hidden:
+  localgov_access_control: true
   localgov_service_status: true
   localgov_service_status_on_landi: true
   localgov_service_status_on_list: true

--- a/config/default/core.entity_view_display.node.localgov_services_sublanding.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_sublanding.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -30,4 +31,6 @@ hidden:
   body: true
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_sublanding.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_sublanding.grid_item.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.grid_item
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -29,6 +30,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_topics: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_sublanding.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_sublanding.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -46,4 +47,5 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_sublanding.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -29,5 +30,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_topics: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_services_sublanding.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_services_sublanding.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_services_sublanding.body
+    - field.field.node.localgov_services_sublanding.localgov_access_control
     - field.field.node.localgov_services_sublanding.localgov_services_parent
     - field.field.node.localgov_services_sublanding.localgov_topics
     - node.type.localgov_services_sublanding
@@ -29,5 +30,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_topics: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_overview.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -24,14 +25,20 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
-  links:
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_overview.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_overview.grid_item.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.grid_item
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -35,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_overview.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_overview.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -26,6 +27,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_services_parent:
     type: entity_reference_label
@@ -60,4 +66,5 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_overview.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -28,8 +29,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_overview.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_overview.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_step_by_step_overview.body
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
     - field.field.node.localgov_step_by_step_overview.localgov_services_parent
     - field.field.node.localgov_step_by_step_overview.localgov_step_by_step_pages
     - field.field.node.localgov_step_by_step_overview.localgov_step_description
@@ -28,8 +29,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_services_parent: true
   localgov_step_by_step_pages: true
   localgov_step_description: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.localgov_step_by_step_page.body
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
     - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
@@ -23,14 +24,20 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
-  links:
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
     weight: 0
     region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
+  localgov_access_control: true
   localgov_step_parent: true
   localgov_step_section_title: true
   localgov_step_summary: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_page.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_page.search_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_index
     - field.field.node.localgov_step_by_step_page.body
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
     - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
@@ -25,6 +26,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 0
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
     region: content
   localgov_step_parent:
     type: entity_reference_label
@@ -51,4 +57,5 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_page.search_result.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.search_result
     - field.field.node.localgov_step_by_step_page.body
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
     - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
@@ -27,8 +28,14 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_step_parent: true
   localgov_step_section_title: true
   localgov_step_summary: true

--- a/config/default/core.entity_view_display.node.localgov_step_by_step_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_step_by_step_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.localgov_step_by_step_page.body
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
     - field.field.node.localgov_step_by_step_page.localgov_step_parent
     - field.field.node.localgov_step_by_step_page.localgov_step_section_title
     - field.field.node.localgov_step_by_step_page.localgov_step_summary
@@ -27,12 +28,18 @@ content:
     third_party_settings: {  }
     weight: 101
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
     weight: 100
     region: content
 hidden:
+  localgov_access_control: true
   localgov_step_parent: true
   localgov_step_section_title: true
   localgov_step_summary: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_overview.localgov_access_control
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
     - field.field.node.localgov_subsites_overview.localgov_subsites_hide_menu
@@ -35,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_hide_menu: true
   localgov_subsites_pages: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_subsites_overview.localgov_access_control
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
     - field.field.node.localgov_subsites_overview.localgov_subsites_hide_menu
@@ -43,6 +44,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_hide_menu: true
   localgov_subsites_pages: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_subsites_overview.localgov_access_control
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
     - field.field.node.localgov_subsites_overview.localgov_subsites_hide_menu
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_hide_menu: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.localgov_subsites_overview.localgov_access_control
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
     - field.field.node.localgov_subsites_overview.localgov_subsites_hide_menu
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_hide_menu: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_page.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_page.localgov_access_control
     - field.field.node.localgov_subsites_page.localgov_subsites_banner
     - field.field.node.localgov_subsites_page.localgov_subsites_content
     - field.field.node.localgov_subsites_page.localgov_subsites_parent
@@ -35,6 +36,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_parent: true
   localgov_subsites_summary: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_page.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_page.search_index.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_subsites_page.localgov_access_control
     - field.field.node.localgov_subsites_page.localgov_subsites_banner
     - field.field.node.localgov_subsites_page.localgov_subsites_content
     - field.field.node.localgov_subsites_page.localgov_subsites_parent
@@ -61,5 +62,6 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   search_api_excerpt: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_page.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_page.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_subsites_page.localgov_access_control
     - field.field.node.localgov_subsites_page.localgov_subsites_banner
     - field.field.node.localgov_subsites_page.localgov_subsites_content
     - field.field.node.localgov_subsites_page.localgov_subsites_parent
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_parent: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_page.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.localgov_subsites_page.localgov_access_control
     - field.field.node.localgov_subsites_page.localgov_subsites_banner
     - field.field.node.localgov_subsites_page.localgov_subsites_content
     - field.field.node.localgov_subsites_page.localgov_subsites_parent
@@ -33,6 +34,7 @@ content:
     region: content
 hidden:
   links: true
+  localgov_access_control: true
   localgov_subsites_banner: true
   localgov_subsites_content: true
   localgov_subsites_parent: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -85,6 +85,7 @@ module:
   linkit: 0
   localgov_admin_theme_improvements: 0
   localgov_alert_banner: 0
+  localgov_content_access_control: 0
   localgov_core: 0
   localgov_directories: 0
   localgov_directories_db: 0
@@ -178,6 +179,8 @@ module:
   viewsreference: 0
   webform: 0
   webform_ui: 0
+  workbench: 0
+  workbench_access: 0
   workflows: 0
   pathauto: 1
   externalauth: 10

--- a/config/default/field.field.node.localgov_directories_org.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_directories_org.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 73be75a1-f035-4a90-b4ea-f3a74e2681b1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_directories_org
+    - taxonomy.vocabulary.access_control
+id: node.localgov_directories_org.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_directories_org
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_directories_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_directories_page.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 7db5da20-bca5-4e25-b199-224a0143013e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_directories_page
+    - taxonomy.vocabulary.access_control
+id: node.localgov_directories_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_directories_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_directories_venue.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_directories_venue.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: b78d8597-ccdf-4b33-9446-5ee898dad8c9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_directories_venue
+    - taxonomy.vocabulary.access_control
+id: node.localgov_directories_venue.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_directories_venue
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_directory.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_directory.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 52f5f0d9-6281-449c-865a-49f16c536996
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_directory
+    - taxonomy.vocabulary.access_control
+id: node.localgov_directory.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_directory
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_directory_promo_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_directory_promo_page.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 9a049284-9d4b-47c4-890d-0585bd31e535
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_directory_promo_page
+    - taxonomy.vocabulary.access_control
+id: node.localgov_directory_promo_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_directory_promo_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_event.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_event.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 497be47a-d5f2-4610-9a89-8071bb0eabac
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_event
+    - taxonomy.vocabulary.access_control
+id: node.localgov_event.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_event
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_guides_overview.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_guides_overview.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: adbeb3aa-9d11-4a59-a8bb-9493308669b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_guides_overview
+    - taxonomy.vocabulary.access_control
+id: node.localgov_guides_overview.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_guides_overview
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_guides_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_guides_page.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 59dd318e-fe00-4bce-99cd-82209b83e262
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_guides_page
+    - taxonomy.vocabulary.access_control
+id: node.localgov_guides_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_guides_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_news_article.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_news_article.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 25b9f31a-8af3-4c09-b2d9-62f7c3493acc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_news_article
+    - taxonomy.vocabulary.access_control
+id: node.localgov_news_article.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_news_article
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_newsroom.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_newsroom.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: fe74a2d2-c49e-411d-9c2c-15ae7a1bfe66
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_newsroom
+    - taxonomy.vocabulary.access_control
+id: node.localgov_newsroom.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_newsroom
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_landing.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_services_landing.localgov_access_control.yml
@@ -1,0 +1,31 @@
+uuid: 247b5f00-cddf-4e0e-bf45-9e8b72511212
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_services_landing
+    - taxonomy.vocabulary.access_control
+_core:
+  default_config_hash: 16w3yuLiLXR-sbxqnVXNUifIJqtYv1LrSGLraGfCFmQ
+id: node.localgov_services_landing.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_services_landing
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_services_page.localgov_access_control.yml
@@ -1,0 +1,31 @@
+uuid: 7d55e2be-0c98-41a0-9c47-cfe051f1a2fa
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_services_page
+    - taxonomy.vocabulary.access_control
+_core:
+  default_config_hash: EjC4_r2ltxe7oK2PRvDtn9D1__YXwkmBfGiTbyziKSs
+id: node.localgov_services_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_services_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_status.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_services_status.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 29418c7f-60fb-477b-81a6-8b23c52e0595
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_services_status
+    - taxonomy.vocabulary.access_control
+id: node.localgov_services_status.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_services_status
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_services_sublanding.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_services_sublanding.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: 9faa9ff0-2df7-4a7c-af8d-bd466f68b110
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_services_sublanding
+    - taxonomy.vocabulary.access_control
+id: node.localgov_services_sublanding.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_services_sublanding
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_step_by_step_overview.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_step_by_step_overview.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: d16495a7-cad6-4fb8-8bde-8ad108bf2c4f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_step_by_step_overview
+    - taxonomy.vocabulary.access_control
+id: node.localgov_step_by_step_overview.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_step_by_step_overview
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_step_by_step_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_step_by_step_page.localgov_access_control.yml
@@ -1,0 +1,29 @@
+uuid: a16a7fd1-d1eb-4a25-ab7b-a5d8576feadb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_step_by_step_page
+    - taxonomy.vocabulary.access_control
+id: node.localgov_step_by_step_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_step_by_step_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_subsites_overview.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_subsites_overview.localgov_access_control.yml
@@ -1,0 +1,31 @@
+uuid: 5905bc4c-d98e-4f87-bebf-2d2305bd75ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_subsites_overview
+    - taxonomy.vocabulary.access_control
+_core:
+  default_config_hash: ubRVnUQ0qyZbRUvHF-BcMuHccact_2s4_nZ0hXu5O3I
+id: node.localgov_subsites_overview.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_subsites_overview
+label: 'Access Control'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.field.node.localgov_subsites_page.localgov_access_control.yml
+++ b/config/default/field.field.node.localgov_subsites_page.localgov_access_control.yml
@@ -1,0 +1,31 @@
+uuid: 86a601d6-26ba-4527-a2d6-b27fe1931058
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_access_control
+    - node.type.localgov_subsites_page
+    - taxonomy.vocabulary.access_control
+_core:
+  default_config_hash: KAGh0ddaLzusbioDNzOSzPS-lFUhLozCGmaOwLNhCd8
+id: node.localgov_subsites_page.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+bundle: localgov_subsites_page
+label: 'Access Control'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      access_control: access_control
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.storage.node.localgov_access_control.yml
+++ b/config/default/field.storage.node.localgov_access_control.yml
@@ -1,0 +1,22 @@
+uuid: 74baae17-ecdb-4829-b089-01bcc196a8e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+_core:
+  default_config_hash: Icq0ygv6J3xSC35BvqLZAxHj-H1jT6XDcX0E4csZ108
+id: node.localgov_access_control
+field_name: localgov_access_control
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/config/default/system.action.user_add_role_action.localgov_devolved_editor.yml
+++ b/config/default/system.action.user_add_role_action.localgov_devolved_editor.yml
@@ -1,0 +1,14 @@
+uuid: a6c92669-8ae5-4670-9247-9b03a5f383f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.localgov_devolved_editor
+  module:
+    - user
+id: user_add_role_action.localgov_devolved_editor
+label: 'Add the Devolved Editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: localgov_devolved_editor

--- a/config/default/system.action.user_remove_role_action.localgov_devolved_editor.yml
+++ b/config/default/system.action.user_remove_role_action.localgov_devolved_editor.yml
@@ -1,0 +1,14 @@
+uuid: ca481843-d4a0-4200-8258-3b1d2192925f
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.localgov_devolved_editor
+  module:
+    - user
+id: user_remove_role_action.localgov_devolved_editor
+label: 'Remove the Devolved Editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: localgov_devolved_editor

--- a/config/default/system.menu.workbench.yml
+++ b/config/default/system.menu.workbench.yml
@@ -1,0 +1,10 @@
+uuid: e40aa70a-87c0-47ad-b6ef-b3b79d89b941
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: Uk5hyWhkNv7DHmWKBBnOc-W05llRdbXe19rUxCsSt8Y
+id: workbench
+label: Workbench
+description: 'The editorial workbench.'
+locked: true

--- a/config/default/taxonomy.vocabulary.access_control.yml
+++ b/config/default/taxonomy.vocabulary.access_control.yml
@@ -1,0 +1,10 @@
+uuid: e871ebee-ca61-4230-ac17-9bae9f1051e5
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: _3P89wr0yO4XkiCj5TnkZF204hXPW0HSLcq4YVquprE
+name: 'Access Control'
+vid: access_control
+description: 'We use this taxonomy to control edit/publish/etc access to different site sections.'
+weight: 0

--- a/config/default/user.role.analytics.yml
+++ b/config/default/user.role.analytics.yml
@@ -6,6 +6,8 @@ dependencies:
     - eu_cookie_compliance
     - system
     - toolbar
+    - workbench
+    - workbench_access
 id: analytics
 label: Analytics
 weight: -7
@@ -13,6 +15,9 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access toolbar'
+  - 'access workbench'
   - 'administer eu cookie compliance categories'
   - 'administer eu cookie compliance popup'
+  - 'use workbench access'
   - 'view the administration theme'
+  - 'view workbench access information'

--- a/config/default/user.role.emergency_publisher.yml
+++ b/config/default/user.role.emergency_publisher.yml
@@ -11,6 +11,8 @@ dependencies:
     - scheduled_transitions
     - system
     - toolbar
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_alert_banner
@@ -23,14 +25,17 @@ is_admin: null
 permissions:
   - 'access localgov alert banner listing page'
   - 'access toolbar'
+  - 'access workbench'
   - 'add scheduled transitions localgov_alert_banner localgov_alert_banner'
   - 'manage all localgov alert banner entities'
   - 'use localgov_alert_banners transition create_new_draft'
   - 'use localgov_alert_banners transition publish'
   - 'use localgov_alert_banners transition unpublish'
+  - 'use workbench access'
   - 'view all localgov alert banner entities'
   - 'view all localgov alert banner entity pages'
   - 'view all scheduled transitions'
   - 'view localgov alert banner localgov_alert_banner pages'
   - 'view scheduled transitions localgov_alert_banner localgov_alert_banner'
   - 'view the administration theme'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_author.yml
+++ b/config/default/user.role.localgov_author.yml
@@ -48,6 +48,8 @@ dependencies:
     - system
     - toolbar
     - webform
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_roles
@@ -69,6 +71,7 @@ permissions:
   - 'access paragraphs_library_items entity browser pages'
   - 'access responsive preview'
   - 'access toolbar'
+  - 'access workbench'
   - 'add scheduled transitions node localgov_directories_page'
   - 'add scheduled transitions node localgov_directories_venue'
   - 'add scheduled transitions node localgov_directory_promo_page'
@@ -172,6 +175,7 @@ permissions:
   - 'use localgov_editorial transition publish'
   - 'use localgov_editorial transition reject'
   - 'use localgov_editorial transition submit_for_review'
+  - 'use workbench access'
   - 'view all localgov alert banner entity pages'
   - 'view all media revisions'
   - 'view all revisions'
@@ -223,3 +227,4 @@ permissions:
   - 'view scheduled transitions node localgov_subsites_page'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_contributor.yml
+++ b/config/default/user.role.localgov_contributor.yml
@@ -45,6 +45,8 @@ dependencies:
     - system
     - toolbar
     - webform
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_roles
@@ -64,6 +66,7 @@ permissions:
   - 'access paragraphs_library_items entity browser pages'
   - 'access responsive preview'
   - 'access toolbar'
+  - 'access workbench'
   - 'add scheduled transitions node localgov_directories_page'
   - 'add scheduled transitions node localgov_directories_venue'
   - 'add scheduled transitions node localgov_directory_promo_page'
@@ -139,6 +142,7 @@ permissions:
   - 'use localgov_editorial transition create_new_draft'
   - 'use localgov_editorial transition reject'
   - 'use localgov_editorial transition submit_for_review'
+  - 'use workbench access'
   - 'view all localgov alert banner entity pages'
   - 'view all media revisions'
   - 'view all revisions'
@@ -189,3 +193,4 @@ permissions:
   - 'view scheduled transitions node localgov_subsites_page'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_devolved_editor.yml
+++ b/config/default/user.role.localgov_devolved_editor.yml
@@ -1,0 +1,83 @@
+uuid: 285c4ee3-3d08-428a-90b4-1c8f66157337
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.localgov_directories_page
+    - node.type.localgov_directories_venue
+    - node.type.localgov_event
+    - node.type.localgov_guides_overview
+    - node.type.localgov_guides_page
+    - node.type.localgov_news_article
+    - node.type.localgov_newsroom
+    - node.type.localgov_services_landing
+    - node.type.localgov_services_page
+    - node.type.localgov_services_status
+    - node.type.localgov_services_sublanding
+    - node.type.localgov_step_by_step_overview
+    - node.type.localgov_step_by_step_page
+    - node.type.localgov_subsites_overview
+    - node.type.localgov_subsites_page
+    - workflows.workflow.localgov_alert_banners
+    - workflows.workflow.localgov_editorial
+  module:
+    - content_moderation
+    - media
+    - node
+    - system
+    - toolbar
+    - workbench
+    - workbench_access
+_core:
+  default_config_hash: rwlUC2eR655eEFydq8nHQZJB57N7jR1ZCga82z_lmhY
+id: localgov_devolved_editor
+label: 'Devolved Editor'
+weight: -2
+is_admin: null
+permissions:
+  - 'access administration pages'
+  - 'access content'
+  - 'access site in maintenance mode'
+  - 'access toolbar'
+  - 'access user profiles'
+  - 'access workbench'
+  - 'create localgov_event content'
+  - 'create localgov_guides_overview content'
+  - 'create localgov_guides_page content'
+  - 'create localgov_news_article content'
+  - 'create localgov_services_page content'
+  - 'create localgov_step_by_step_page content'
+  - 'edit any localgov_directories_page content'
+  - 'edit any localgov_directories_venue content'
+  - 'edit any localgov_event content'
+  - 'edit any localgov_guides_overview content'
+  - 'edit any localgov_guides_page content'
+  - 'edit any localgov_news_article content'
+  - 'edit any localgov_newsroom content'
+  - 'edit any localgov_services_landing content'
+  - 'edit any localgov_services_page content'
+  - 'edit any localgov_services_status content'
+  - 'edit any localgov_services_sublanding content'
+  - 'edit any localgov_step_by_step_overview content'
+  - 'edit any localgov_step_by_step_page content'
+  - 'edit any localgov_subsites_overview content'
+  - 'edit any localgov_subsites_page content'
+  - 'edit own localgov_subsites_overview content'
+  - 'use localgov_alert_banners transition create_new_draft'
+  - 'use localgov_alert_banners transition publish'
+  - 'use localgov_alert_banners transition unpublish'
+  - 'use localgov_editorial transition approve'
+  - 'use localgov_editorial transition archive'
+  - 'use localgov_editorial transition archived_draft'
+  - 'use localgov_editorial transition archived_published'
+  - 'use localgov_editorial transition create_new_draft'
+  - 'use localgov_editorial transition publish'
+  - 'use localgov_editorial transition reject'
+  - 'use localgov_editorial transition submit_for_review'
+  - 'use workbench access'
+  - 'view any unpublished content'
+  - 'view latest version'
+  - 'view media'
+  - 'view own unpublished content'
+  - 'view the administration theme'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_editor.yml
+++ b/config/default/user.role.localgov_editor.yml
@@ -25,6 +25,7 @@ dependencies:
     - node.type.localgov_step_by_step_page
     - node.type.localgov_subsites_overview
     - node.type.localgov_subsites_page
+    - taxonomy.vocabulary.access_control
     - workflows.workflow.localgov_alert_banners
     - workflows.workflow.localgov_editorial
   module:
@@ -48,8 +49,11 @@ dependencies:
     - responsive_preview
     - scheduled_transitions
     - system
+    - taxonomy
     - toolbar
     - webform
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_roles
@@ -73,6 +77,7 @@ permissions:
   - 'access responsive preview'
   - 'access toolbar'
   - 'access webform overview'
+  - 'access workbench'
   - 'add content owner/sme entity'
   - 'add scheduled transitions localgov_alert_banner localgov_alert_banner'
   - 'add scheduled transitions node localgov_directories_org'
@@ -115,6 +120,7 @@ permissions:
   - 'create media'
   - 'create paragraph library item'
   - 'create remote_video media'
+  - 'create terms in access_control'
   - 'create url aliases'
   - 'create webform'
   - 'delete any localgov_event content'
@@ -131,6 +137,7 @@ permissions:
   - 'delete geo'
   - 'delete localgov_event revisions'
   - 'delete own localgov_event content'
+  - 'delete terms in access_control'
   - 'edit any document media'
   - 'edit any image media'
   - 'edit any localgov_directories_org content'
@@ -179,6 +186,7 @@ permissions:
   - 'edit own remote_video media'
   - 'edit own webform'
   - 'edit paragraph library item'
+  - 'edit terms in access_control'
   - 'generate preview links'
   - 'manage localgov alert banner localgov_alert_banner entities'
   - 'reorder entity_hierarchy children'
@@ -233,6 +241,7 @@ permissions:
   - 'use localgov_editorial transition publish'
   - 'use localgov_editorial transition reject'
   - 'use localgov_editorial transition submit_for_review'
+  - 'use workbench access'
   - 'view all localgov alert banner entity pages'
   - 'view all media revisions'
   - 'view all revisions'
@@ -284,3 +293,4 @@ permissions:
   - 'view scheduled transitions node localgov_subsites_page'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_news_editor.yml
+++ b/config/default/user.role.localgov_news_editor.yml
@@ -43,6 +43,8 @@ dependencies:
     - scheduled_transitions
     - system
     - toolbar
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_news
@@ -59,6 +61,7 @@ permissions:
   - 'access media overview'
   - 'access responsive preview'
   - 'access toolbar'
+  - 'access workbench'
   - 'add scheduled transitions localgov_alert_banner localgov_alert_banner'
   - 'add scheduled transitions node localgov_news_article'
   - 'add scheduled transitions node localgov_newsroom'
@@ -120,6 +123,7 @@ permissions:
   - 'use localgov_editorial transition publish'
   - 'use localgov_editorial transition reject'
   - 'use localgov_editorial transition submit_for_review'
+  - 'use workbench access'
   - 'view all localgov alert banner entity pages'
   - 'view all localgov_news_article revisions'
   - 'view all scheduled transitions'
@@ -155,3 +159,4 @@ permissions:
   - 'view scheduled transitions node localgov_subsites_overview'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'view workbench access information'

--- a/config/default/user.role.localgov_user_manager.yml
+++ b/config/default/user.role.localgov_user_manager.yml
@@ -9,6 +9,8 @@ dependencies:
     - system
     - toolbar
     - webform
+    - workbench
+    - workbench_access
   enforced:
     module:
       - localgov_roles
@@ -21,6 +23,7 @@ is_admin: null
 permissions:
   - 'access toolbar'
   - 'access user profiles'
+  - 'access workbench'
   - 'administer cludo search'
   - 'administer search_api'
   - 'administer users'
@@ -32,6 +35,8 @@ permissions:
   - 'assign localgov_news_editor role'
   - 'assign localgov_user_manager role'
   - 'delete any webform submission'
+  - 'use workbench access'
   - 'view any webform submission'
   - 'view the administration theme'
   - 'view user email addresses'
+  - 'view workbench access information'

--- a/config/default/views.settings.yml
+++ b/config/default/views.settings.yml
@@ -6,7 +6,7 @@ sql_signature: false
 ui:
   show:
     additional_queries: false
-    advanced_column: false
+    advanced_column: true
     default_display: false
     performance_statistics: false
     preview_information: true

--- a/config/default/views.view.workbench_current_user.yml
+++ b/config/default/views.view.workbench_current_user.yml
@@ -15,45 +15,12 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-      row:
-        type: fields
+      title: ''
       fields:
         uid:
           id: uid
@@ -62,6 +29,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -118,9 +88,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: uid
-          plugin_id: field
         name:
           id: name
           table: users_field_data
@@ -128,6 +95,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -183,9 +153,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
         edit_user:
           id: edit_user
           table: users
@@ -193,6 +160,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -235,8 +204,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: 'Edit my profile'
-          entity_type: user
-          plugin_id: entity_link_edit
         access:
           id: access
           table: users_field_data
@@ -244,6 +211,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: field
           label: 'Last visit'
           exclude: false
           alter:
@@ -301,9 +271,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: access
-          plugin_id: field
         roles:
           id: roles
           table: user__roles
@@ -311,6 +278,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
           label: 'Assigned roles'
           exclude: false
           alter:
@@ -354,9 +324,31 @@ display:
           hide_alter_empty: true
           type: entity_reference_label
           separator: ', '
-          entity_type: user
-          entity_field: roles
-          plugin_id: user_roles
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         uid_current:
           id: uid_current
@@ -365,6 +357,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: user_current
           operator: '='
           value: '1'
           group: 1
@@ -375,14 +369,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -395,10 +389,19 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: user
-          plugin_id: user_current
-      sorts: {  }
-      title: ''
+      style:
+        type: default
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         area:
           id: area
@@ -407,16 +410,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: true
           content:
             value: '<h3>{{ name }}''s profile</h3>'
             format: basic_html
-          plugin_id: text
+          tokenize: true
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -427,13 +427,13 @@ display:
         - user.permissions
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Overview block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       display_description: 'Displays information about the current user.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/default/views.view.workbench_current_user.yml
+++ b/config/default/views.view.workbench_current_user.yml
@@ -1,0 +1,444 @@
+uuid: fd68f3a7-80ab-4a30-b81b-b8ffd5ae2e06
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+_core:
+  default_config_hash: x0E2jGoxP9eHkfDCa_squULlpvddE5h3gln_1oKeViY
+id: workbench_current_user
+label: 'Workbench: Current user'
+module: views
+description: 'Information about the current user.'
+tag: Workbench
+base_table: users_field_data
+base_field: uid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        uid:
+          id: uid
+          table: users_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: uid
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+        edit_user:
+          id: edit_user
+          table: users
+          field: edit_user
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: 'Edit my profile'
+          entity_type: user
+          plugin_id: entity_link_edit
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Last visit'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: long
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: access
+          plugin_id: field
+        roles:
+          id: roles
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Assigned roles'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: entity_reference_label
+          separator: ', '
+          entity_type: user
+          entity_field: roles
+          plugin_id: user_roles
+      filters:
+        uid_current:
+          id: uid_current
+          table: users
+          field: uid_current
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          plugin_id: user_current
+      sorts: {  }
+      title: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: true
+          content:
+            value: '<h3>{{ name }}''s profile</h3>'
+            format: basic_html
+          plugin_id: text
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'Overview block'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: 'Displays information about the current user.'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - user.permissions
+      tags: {  }

--- a/config/default/views.view.workbench_edited.yml
+++ b/config/default/views.view.workbench_edited.yml
@@ -16,114 +16,12 @@ base_table: node_field_revision
 base_field: vid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access workbench'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: true
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '10,25,50,100,200'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            nid: nid
-            title: title
-            type: type
-            status: status
-            changed: changed
-          info:
-            nid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: false
-      row:
-        type: fields
+      title: 'My Edits'
       fields:
         nid:
           id: nid
@@ -132,6 +30,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -188,9 +89,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: field
         title:
           id: title
           table: node_field_revision
@@ -198,6 +96,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -253,9 +154,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -263,6 +161,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
           label: Type
           exclude: false
           alter:
@@ -318,9 +219,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
         status:
           id: status
           table: node_field_data
@@ -328,6 +226,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
           label: Published
           exclude: false
           alter:
@@ -373,8 +274,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -385,9 +286,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: status
-          plugin_id: field
         changed:
           id: changed
           table: node_field_revision
@@ -395,6 +293,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
           label: 'Last updated'
           exclude: false
           alter:
@@ -452,9 +353,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: changed
-          plugin_id: field
         uid:
           id: uid
           table: node_field_revision
@@ -462,6 +360,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -517,9 +418,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: field
         revision_uid:
           id: revision_uid
           table: node_revision
@@ -527,6 +425,9 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: revision_uid
+          plugin_id: field
           label: 'Revised by'
           exclude: false
           alter:
@@ -582,201 +483,44 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: revision_uid
-          plugin_id: field
-      filters:
-        title:
-          id: title
-          table: node_field_revision
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
           expose:
-            operator_id: title_op
-            label: Title
-            description: ''
-            use_operator: false
-            operator: title_op
-            identifier: title
-            required: false
-            remember: true
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: title
-          plugin_id: string
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: vid
-          group_type: group
-          admin_label: ''
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: type_op
-            label: Type
-            description: ''
-            use_operator: false
-            operator: type_op
-            identifier: type
-            required: false
-            remember: true
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        status:
-          id: status
-          table: node_field_data
-          field: status
-          relationship: vid
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Published
-            description: ''
-            use_operator: false
-            operator: status_op
-            identifier: published
-            required: false
-            remember: true
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              editor: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
-        type_1:
-          id: type_1
-          table: node_field_data
-          field: type
-          relationship: vid
-          group_type: group
-          admin_label: ''
-          operator: 'not empty'
-          value: {  }
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-      sorts:
-        changed:
-          id: changed
-          table: node_field_revision
-          field: changed
-          relationship: vid
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-            field_identifier: changed
-          granularity: second
-          entity_type: node
-          entity_field: changed
-          plugin_id: date
-      title: 'My Edits'
-      header: {  }
-      footer: {  }
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10,25,50,100,200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access workbench'
+      cache:
+        type: tag
+        options: {  }
       empty:
         area:
           id: area
@@ -785,35 +529,29 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: 'You haven''t created or edited any content.'
             format: basic_html
-          plugin_id: text
-      relationships:
-        uid:
-          id: uid
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
           table: node_field_revision
-          field: uid
-          relationship: none
+          field: changed
+          relationship: vid
           group_type: group
-          admin_label: User
-          required: false
+          admin_label: ''
           entity_type: node
-          entity_field: uid
-          plugin_id: standard
-        vid:
-          id: vid
-          table: node_field_revision
-          field: vid
-          relationship: none
-          group_type: group
-          admin_label: 'Get the actual content from a content revision.'
-          required: false
-          entity_type: node
-          entity_field: vid
-          plugin_id: standard
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
       arguments:
         uid_revision:
           id: uid_revision
@@ -822,6 +560,8 @@ display:
           relationship: vid
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_uid_revision
           default_action: default
           exception:
             value: all
@@ -835,8 +575,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -848,108 +588,38 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: node
-          plugin_id: node_uid_revision
-      display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      use_ajax: false
-      link_url: /admin
-      link_display: '0'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  block_1:
-    display_plugin: block
-    id: block_1
-    display_title: 'Overview block'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      pager:
-        type: full
-        options:
-          items_per_page: 5
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      defaults:
-        pager: false
-        header: false
-        filters: false
-        filter_groups: false
-        footer: false
-        use_more: false
-        use_more_always: false
-        use_more_text: false
-        link_display: true
-        link_url: true
-        use_ajax: false
-      header:
-        area:
-          id: area
-          table: views
-          field: area
+      filters:
+        title:
+          id: title
+          table: node_field_revision
+          field: title
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: '<h3>Your most recent edits</h3>'
-            format: basic_html
-          plugin_id: text
-      filters:
-        type_1:
-          id: type_1
-          table: node_field_data
-          field: type
-          relationship: vid
-          group_type: group
-          admin_label: ''
-          operator: 'not empty'
-          value: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
           group: 1
-          exposed: false
+          exposed: true
           expose:
-            operator_id: ''
-            label: ''
+            operator_id: title_op
+            label: Title
             description: ''
             use_operator: false
-            operator: ''
-            identifier: ''
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
             required: false
-            remember: false
+            remember: true
             multiple: false
             remember_roles:
               authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
           is_grouped: false
           group_info:
             label: ''
@@ -962,20 +632,350 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: published
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            nid: nid
+            title: title
+            type: type
+            status: status
+            changed: changed
+          default: changed
+          info:
+            nid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_revision
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+          required: false
+        vid:
+          id: vid
+          table: node_field_revision
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: 'Get the actual content from a content revision.'
+          entity_type: node
+          entity_field: vid
+          plugin_id: standard
+          required: false
+      use_ajax: false
+      link_display: '0'
+      link_url: /admin
+      header: {  }
       footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: 'Overview block'
+    display_plugin: block
+    position: 2
+    display_options:
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 5
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      filters:
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        use_ajax: false
+        pager: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        link_display: true
+        link_url: true
+        filters: false
+        filter_groups: false
+        header: false
+        footer: false
+      use_ajax: true
+      display_description: 'The five most recent edits by this user'
       use_more: false
       use_more_always: false
       use_more_text: 'view all'
       link_display: /admin/workbench/content/edited
-      display_description: 'The five most recent edits by this user'
-      use_ajax: true
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h3>Your most recent edits</h3>'
+            format: basic_html
+          tokenize: false
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -988,13 +988,13 @@ display:
         - user.permissions
       tags: {  }
   embed_1:
-    display_plugin: embed
     id: embed_1
     display_title: 'Page Embed'
+    display_plugin: embed
     position: 3
     display_options:
-      display_extenders: {  }
       display_description: 'The embedded view for use on a landing page'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/default/views.view.workbench_edited.yml
+++ b/config/default/views.view.workbench_edited.yml
@@ -1,0 +1,1008 @@
+uuid: 81cc47c8-06d5-479e-b68f-9272088246b4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+_core:
+  default_config_hash: WMpzvSWjygJfcGxqX_wcDKoUpyl9ihHN0zbCJVzVhXw
+id: workbench_edited
+label: 'Workbench: Edits by user'
+module: views
+description: 'Lists content edited by the user.'
+tag: Workbench
+base_table: node_field_revision
+base_field: vid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access workbench'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 25
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10,25,50,100,200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            nid: nid
+            title: title
+            type: type
+            status: status
+            changed: changed
+          info:
+            nid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: changed
+          empty_table: false
+      row:
+        type: fields
+      fields:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_revision
+          field: title
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_true: ''
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+        changed:
+          id: changed
+          table: node_field_revision
+          field: changed
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: 'Last updated'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+        uid:
+          id: uid
+          table: node_field_revision
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
+        revision_uid:
+          id: revision_uid
+          table: node_revision
+          field: revision_uid
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          label: 'Revised by'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: revision_uid
+          plugin_id: field
+      filters:
+        title:
+          id: title
+          table: node_field_revision
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            identifier: published
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        changed:
+          id: changed
+          table: node_field_revision
+          field: changed
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+            field_identifier: changed
+          granularity: second
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+      title: 'My Edits'
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'You haven''t created or edited any content.'
+            format: basic_html
+          plugin_id: text
+      relationships:
+        uid:
+          id: uid
+          table: node_field_revision
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+        vid:
+          id: vid
+          table: node_field_revision
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: 'Get the actual content from a content revision.'
+          required: false
+          entity_type: node
+          entity_field: vid
+          plugin_id: standard
+      arguments:
+        uid_revision:
+          id: uid_revision
+          table: node_field_data
+          field: uid_revision
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: current_user
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          plugin_id: node_uid_revision
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      use_ajax: false
+      link_url: /admin
+      link_display: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'Overview block'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      pager:
+        type: full
+        options:
+          items_per_page: 5
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      defaults:
+        pager: false
+        header: false
+        filters: false
+        filter_groups: false
+        footer: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        link_display: true
+        link_url: true
+        use_ajax: false
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: '<h3>Your most recent edits</h3>'
+            format: basic_html
+          plugin_id: text
+      filters:
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: vid
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: {  }
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      footer: {  }
+      use_more: false
+      use_more_always: false
+      use_more_text: 'view all'
+      link_display: /admin/workbench/content/edited
+      display_description: 'The five most recent edits by this user'
+      use_ajax: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  embed_1:
+    display_plugin: embed
+    id: embed_1
+    display_title: 'Page Embed'
+    position: 3
+    display_options:
+      display_extenders: {  }
+      display_description: 'The embedded view for use on a landing page'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/default/views.view.workbench_recent_content.yml
+++ b/config/default/views.view.workbench_recent_content.yml
@@ -1,0 +1,1368 @@
+uuid: d95bc225-ce43-4a29-8175-027b91f12551
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+    - node
+    - user
+    - workbench_access
+_core:
+  default_config_hash: sE8LcWl4XA93if6pA-KTbMmgz3gKkd40g4wxUVmBD8I
+id: workbench_recent_content
+label: 'Workbench: Recent content'
+module: views
+description: 'Content overview page for Workbench.'
+tag: Workbench
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Workbench: Recent content'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: field
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_false: ''
+            format_custom_true: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: 'Last updated'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
+          label: Actions
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: edit
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '10,25,50,100,200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access workbench'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There is no content available for you to edit.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: title
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: true
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: published
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              editor: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status_extra:
+          id: status_extra
+          table: node_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: node_status
+          operator: '='
+          value: false
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            title: title
+            type: type
+            status: status
+            name: name
+            changed: changed
+            edit_node: edit_node
+          default: changed
+          info:
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            edit_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+          required: false
+      use_more: false
+      use_more_always: false
+      use_more_text: 'view all'
+      link_display: '0'
+      link_url: /admin/workbench/content/all
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          plugin_id: text
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: 'Overview block'
+    display_plugin: block
+    position: 2
+    display_options:
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+          label: Type
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: 'Last updated'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        edit_node:
+          id: edit_node
+          table: node
+          field: edit_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
+          label: Actions
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: edit
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 2
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      filters:
+        workbench_access_section__site_section:
+          id: workbench_access_section__site_section
+          table: node
+          field: workbench_access_section__site_section
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: workbench_access_section
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: workbench_access_section__site_section_op
+            label: 'Site Section'
+            description: ''
+            use_operator: false
+            operator: workbench_access_section__site_section_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: workbench_access_section__site_section
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              emergency_publisher: '0'
+              localgov_news_editor: '0'
+              analytics: '0'
+              localgov_contributor: '0'
+              localgov_author: '0'
+              localgov_editor: '0'
+              localgov_user_manager: '0'
+              administrator: '0'
+              localgov_devolved_editor: '0'
+            reduce: 1
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: 0
+          section_filter:
+            show_hierarchy: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              emergency_publisher: '0'
+              localgov_news_editor: '0'
+              analytics: '0'
+              localgov_contributor: '0'
+              localgov_author: '0'
+              localgov_editor: '0'
+              localgov_user_manager: '0'
+              administrator: '0'
+              localgov_devolved_editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              emergency_publisher: '0'
+              localgov_news_editor: '0'
+              analytics: '0'
+              localgov_contributor: '0'
+              localgov_author: '0'
+              localgov_editor: '0'
+              localgov_user_manager: '0'
+              administrator: '0'
+              localgov_devolved_editor: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: moderation_state_filter
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: moderation_state_op
+            label: 'Moderation state'
+            description: ''
+            use_operator: false
+            operator: moderation_state_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: moderation_state
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              emergency_publisher: '0'
+              localgov_news_editor: '0'
+              analytics: '0'
+              localgov_contributor: '0'
+              localgov_author: '0'
+              localgov_editor: '0'
+              localgov_user_manager: '0'
+              administrator: '0'
+              localgov_devolved_editor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        use_ajax: false
+        pager: false
+        use_more: true
+        use_more_always: true
+        use_more_text: true
+        style: true
+        row: true
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
+      use_ajax: true
+      display_description: 'The ten most recent posts to the site'
+      link_display: /admin/workbench/content/all
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h3>Recent content</h3>'
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:workflow_list'
+        - workbench_access_view
+  embed_1:
+    id: embed_1
+    display_title: 'Page Embed'
+    display_plugin: embed
+    position: 3
+    display_options:
+      display_description: 'The embedded view for use on a landing page'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/default/webform.webform.feedback_form.yml
+++ b/config/default/webform.webform.feedback_form.yml
@@ -18,7 +18,7 @@ elements: |-
     '#markup': |-
       <p data-renderer-start-pos="99">Only use this form to give us feedback about our new website.</p>
 
-      <p data-renderer-start-pos="225">For all other enquiries, please <a href="/contact-us">contact us</a> directly.</p>
+      <p data-renderer-start-pos="225">If you want a response, <a aria-label="Link contact the individual service directly." href="https://www.essex.gov.uk/contact-us" rel="noreferrer noopener" target="_blank" title="https://www.essex.gov.uk/contact-us">contact the individual service directly.</a></p>
 
       <p data-renderer-start-pos="296">The information you provide will only be used for the purpose of improving our online services and will not be shared with anyone outside the council.</p>
   reference:
@@ -66,18 +66,21 @@ elements: |-
     '#type': textarea
     '#title': 'Give us more detailed feedback'
     '#description': |-
-      Please do not enter any personal information in this space
-      <div id="extension-host">&nbsp;</div>
+      Do not enter any personal information in this space. Any submissions containing personal information will be deleted.&nbsp;<br />
+      <br />
+      If you want a response, <a aria-label="Link contact the individual service directly." href="https://www.essex.gov.uk/contact-us" rel="noreferrer noopener" target="_blank" title="https://www.essex.gov.uk/contact-us">contact the individual service directly.</a>
+  markup:
+    '#type': webform_markup
+    '#markup': |-
+      Read&nbsp;<a href="https://www.essex.gov.uk/about-essexgovuk/privacy-and-data-protection/your-privacy">the data protection and privacy policy</a>&nbsp;and agree to the council using any personal data that you provide in this form to deal with your request.<br />
+      &nbsp;
   data_use_policy:
     '#type': checkbox
-    '#title': 'Data use policy'
-    '#description': |-
-      Please confirm that you have read <a href="/about-essexgovuk/privacy-and-data-protection/your-privacy">the data protection and privacy policy</a> and agree to the council using any personal data that you provide in this form to deal with your request.
-      <div id="extension-host">&nbsp;</div>
+    '#title': 'I confirm that I have read the data protection and privacy policy'
+    '#required': true
     '#wrapper_attributes':
       class:
         - form-checkboxes
-    '#required': true
 css: ''
 javascript: ''
 settings:
@@ -165,6 +168,8 @@ settings:
   wizard_toggle: false
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''

--- a/config/default/workbench.settings.yml
+++ b/config/default/workbench.settings.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: aGR45_bxRagev3Ecuwgjvr3x2Ccgsmsk-Evv-SIkwQM
+overview_left: 'workbench_current_user:block_1'
+overview_right: 'workbench_edited:block_1'
+overview_main: 'workbench_recent_content:block_1'
+edits_main: 'workbench_edited:embed_1'
+all_main: 'workbench_recent_content:embed_1'

--- a/config/default/workbench_access.access_scheme.site_section.yml
+++ b/config/default/workbench_access.access_scheme.site_section.yml
@@ -1,0 +1,106 @@
+uuid: 686bb04c-45cd-4b74-bb61-a4272009a4d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.localgov_directories_org.localgov_access_control
+    - field.field.node.localgov_directories_page.localgov_access_control
+    - field.field.node.localgov_directories_venue.localgov_access_control
+    - field.field.node.localgov_directory.localgov_access_control
+    - field.field.node.localgov_directory_promo_page.localgov_access_control
+    - field.field.node.localgov_event.localgov_access_control
+    - field.field.node.localgov_guides_overview.localgov_access_control
+    - field.field.node.localgov_guides_page.localgov_access_control
+    - field.field.node.localgov_news_article.localgov_access_control
+    - field.field.node.localgov_newsroom.localgov_access_control
+    - field.field.node.localgov_services_landing.localgov_access_control
+    - field.field.node.localgov_services_page.localgov_access_control
+    - field.field.node.localgov_services_status.localgov_access_control
+    - field.field.node.localgov_services_sublanding.localgov_access_control
+    - field.field.node.localgov_step_by_step_overview.localgov_access_control
+    - field.field.node.localgov_step_by_step_page.localgov_access_control
+    - field.field.node.localgov_subsites_overview.localgov_access_control
+    - field.field.node.localgov_subsites_page.localgov_access_control
+    - taxonomy.vocabulary.access_control
+_core:
+  default_config_hash: On3fSNOuWBdNXh398mhWl1bL0wWUFyU-4YZWvp_YSnU
+id: site_section
+plural_label: 'Site Sections'
+label: 'Site Section'
+scheme: taxonomy
+scheme_settings:
+  vocabularies:
+    - access_control
+  fields:
+    -
+      entity_type: node
+      bundle: localgov_subsites_page
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_subsites_overview
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_services_page
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_services_landing
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_directory
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_directories_org
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_directories_page
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_directory_promo_page
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_directories_venue
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_event
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_guides_overview
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_guides_page
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_news_article
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_newsroom
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_services_status
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_services_sublanding
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_step_by_step_overview
+      field: localgov_access_control
+    -
+      entity_type: node
+      bundle: localgov_step_by_step_page
+      field: localgov_access_control

--- a/config/default/workbench_access.settings.yml
+++ b/config/default/workbench_access.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: Y6xetsHwk8FUA3WQMga3J7Imf3wRlur5ALeppr16dJM
+deny_on_empty: true


### PR DESCRIPTION
PR for Workbench Access to merge to main.

1. Add the LGD access control module to the site
2. Configures the site to have a field called "Access Control" on all content types
3. Adds a "Devolved Editor" role to the site
4. Add an "Access Control" vocabulary that is used to power the "Site Sections" workbench access scheme
5. Allows "User Manager" role to add people to the site sections
6. Allows "Editor" role to create/edit/delete terms in the Access Control vocabulary

Note, since all content types are under access control, **NO EDITOR** will be able to edit content until they are added to a "Site Section" at /admin/config/workflow/workbench_access. The best thing to do will be to add each current editor to the **full "Site Section" section** at /admin/config/workflow/workbench_access/site_section/sections so they can continue to work as normal. _Then_, we can add some terms to the Access Control vocabulary and situate users within specific site sections.
