### PR TITLE
re-enables tabs block

### DIFF
--- a/config/default/block.block.essex_localgov_tabs_scarfolk.yml
+++ b/config/default/block.block.essex_localgov_tabs_scarfolk.yml
@@ -1,6 +1,6 @@
 uuid: a2493a77-cabe-40a0-83eb-c84903c52d1c
 langcode: en
-status: false
+status: true
 dependencies:
   theme:
     - essex


### PR DESCRIPTION
Tabs are available again now.

I am not sure if they were disabled for a specific reason, so this might need chatting about.

![Screenshot 2023-12-07 at 08 47 39](https://github.com/essexcountycouncil/essex-gov-uk-drupal/assets/2183332/f0892386-fe20-441b-ba9c-e0d60e3b453d)
