### PR TITLE
Task/add docksal setup

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -13,7 +13,7 @@ NGINX_VHOST_PRESET=drupal
 
 # Docksal configuration.
 VIRTUAL_HOST=d9-starterkit.docksal.site
-STAGE_FILE_PROXY_URL=https://www.master-7rqtwti-nuqdcyojevolg.eu.platform.sh
+STAGE_FILE_PROXY_URL=https://www.essex.gov.uk
 
 # Default Branch (e.g. main or master)
 DEFAULT_BRANCH="main"

--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -1,1 +1,44 @@
+# Docker and Docker Compose based environment for Drupal.
+# See https://github.com/docksal/docksal for more information and documentation.
+
+# This is a shared configuration file that is intended to be stored in the project repo.
+# For local overrides:
+# - create .docksal/docksal-local.yml file (using example.docksal-local.yml) and put local docker-compose configuration overrides there
+# - ensure .docksal/docksal-local.yml in .gitignore
+
+# Docksal stitches several docker-compose configuration files together.
+# Run "fin config" to see which files are involved and the resulting configuration.
+
 version: "3.9"
+
+services:
+  # Match platform.sh stack
+  web:
+    extends:
+      file: ${HOME}/.docksal/stacks/services.yml
+      service: nginx
+    depends_on:
+      - cli
+
+  redis:
+     hostname: redis
+     image: redis:6.0-alpine
+     volumes:
+       - ${PROJECT_ROOT}/.docksal/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf
+     command: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
+
+# If extra/updated software needed in CLI, see .docksal/services/cli/Dockerfile
+
+# Add or enable non-standard Project services here
+# See https://docs.docksal.io/service/other/ for extra services examples
+
+  # # Solr
+  # # Ensure version & config matches production stack
+  # # See https://docs.docksal.io/service/other/apache-solr/ for extra settings
+  # solr:
+  #   extends:
+  #     file: ${HOME}/.docksal/stacks/services.yml
+  #     service: solr
+  #   image: docksal/solr:8.1-2.1
+  #   volumes:
+  #     - ${PROJECT_ROOT}/.platform/solr-conf/8.x:/var/lib/solr/conf:ro

--- a/.docksal/etc/redis/redis.conf
+++ b/.docksal/etc/redis/redis.conf
@@ -1,0 +1,2 @@
+# Redis config
+maxmemory-policy allkeys-lru

--- a/.docksal/services/cli/Dockerfile
+++ b/.docksal/services/cli/Dockerfile
@@ -1,0 +1,21 @@
+# Allows adding or updating software in CLI image,
+# example below updates platformsh-cli to latest version.
+# To use, update FROM and RUN as needed, then copy following to docksal.yml under services:
+  # cli:
+  #   volumes:
+  #     # Project root volume
+  #     - project_root:/var/www:rw,nocopy,cached
+  #     # Shared ssh-agent socket
+  #     - docksal_ssh_agent:/.ssh-agent:ro
+  #   environment:
+  #     - XDEBUG_ENABLED=${XDEBUG_ENABLED:-0}
+  #     - XDEBUG_CONFIG=client_host=${DOCKSAL_HOST_IP} client_port=9000
+  #     - XDEBUG_MODE=debug
+  #   # Run Dockerfile to add or udpdate software.
+  #   build: services/cli
+
+# Use a stock Docksal php8.1-3 image as the base
+FROM docksal/cli:php8.1-3
+
+RUN set -e; \
+    platform self:update -y || echo "Please update the platform.sh CLI on your host sytem as well by doing a platform self:update"

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ certs/
 
 # Ignore config which may contain secrets
 .ddev/.env
-.docksal
+.docksal/docksal-local.*

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ certs/
 
 # Ignore config which may contain secrets
 .ddev/.env
-.docksal/docksal-local.*


### PR DESCRIPTION
Can we add my default docksal setup to the repo.

Currenlty I have to keep setting .gitignore settings on/off for each branch, so it would be handier to have this alongside the ddev stuff (don't worry, it's beside ddev, not on top of or replacing ddev).