### PR TITLE
Deployment to Preprod fails for develop branch.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,11 +41,8 @@ build-and-push-images:
     - docker build -t ${DOCKER_REGISTRY}/portal-drupal-fpm -t ${DOCKER_REGISTRY}/portal-drupal-fpm${tag} -t portal-drupal-fpm -f Dockerfile-drupal .
     - docker build -t ${DOCKER_REGISTRY}/portal-nginx-drupal -t ${DOCKER_REGISTRY}/portal-nginx-drupal${tag} -t portal-nginx-drupal -f Dockerfile-nginx .
     - docker build -t ${DOCKER_REGISTRY}/portal-nginx-redirect -t ${DOCKER_REGISTRY}/portal-nginx-redirect${tag} -t portal-nginx-redirect -f Dockerfile-nginx-redirect .
-    - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal${tag}
     - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal
-    - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm${tag}
     - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm
-    - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect${tag}
     - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect
 
 generate-sbom:
@@ -210,6 +207,14 @@ deploy-to-preprod:
     - az extension add --name containerapp
     - az login --service-principal -u${ARM_CLIENT_ID} -p${ARM_CLIENT_SECRET} -t${ARM_TENANT_ID}
   script:
+    - |
+      if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
+        tag=""
+        echo "Running on default branch '$CI_DEFAULT_BRANCH': tag = 'latest'"
+      else
+        tag=":$CI_COMMIT_REF_SLUG"
+        echo "Running on branch '$CI_COMMIT_BRANCH': tag = $tag"
+      fi
     - echo "Importing image from Development  into Pre-Production"
     - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
     - az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-drupal:${CI_COMMIT_REF_SLUG} --image portal-nginx-drupal:latest --subscription "Essex County Council (Common)"


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)

Gitlab pipeline fails when deploying _develop_ branch to Preprod. 

```
$ az acr import --force --name acreccukspre --source acreccuksdev.azurecr.io/portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --image portal-nginx-redirect:${CI_COMMIT_REF_SLUG} --subscription "Essex County Council (Common)"
ERROR: (InvalidParameters) Operation registries-8843e49c-c660-11ee-9606-0242ac110002 failed. Resource /subscriptions/d4ffedb7-1180-4fee-9af9-6122b9fcbca5/resourceGroups/rg-ecc-common-uks-pre/providers/Microsoft.ContainerRegistry/registries/acreccukspre Unable to find manifest digest  Repo: portal-nginx-redirect Tag: develop Manifest: 
Code: InvalidParameters
Message: Operation registries-8843e49c-c660-11ee-9606-0242ac110002 failed. Resource /subscriptions/d4ffedb7-1180-4fee-9af9-6122b9fcbca5/resourceGroups/rg-ecc-common-uks-pre/providers/Microsoft.ContainerRegistry/registries/acreccukspre Unable to find manifest digest  Repo: portal-nginx-redirect Tag: develop Manifest: 
Cleaning up project directory and file based variables
00:00
ERROR: Job failed: exit code 1
```
The container repository does not have a _develop_ tag for portal-nginx-redirect. The reason for this isn't understood but hopefully this change will force Preprod to use the _latest_ tag for the _develop_ branch.

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
