### PR TITLE
ECCI-539: Excessive gap in featured teasers removed.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8481,16 +8481,16 @@
     },
     {
       "name": "essexcountycouncil/ecc_theme",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "source": {
         "type": "git",
         "url": "https://github.com/essexcountycouncil/ecc_theme.git",
-        "reference": "5fd2fade88de06147821766f1d048ead8ef9d00c"
+        "reference": "aefe7ad6f43af05088f0270ad3a2cd1f04676ec9"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/essexcountycouncil/ecc_theme/zipball/5fd2fade88de06147821766f1d048ead8ef9d00c",
-        "reference": "5fd2fade88de06147821766f1d048ead8ef9d00c",
+        "url": "https://api.github.com/repos/essexcountycouncil/ecc_theme/zipball/aefe7ad6f43af05088f0270ad3a2cd1f04676ec9",
+        "reference": "aefe7ad6f43af05088f0270ad3a2cd1f04676ec9",
         "shasum": ""
       },
       "type": "drupal-theme",
@@ -8502,10 +8502,10 @@
       ],
       "description": "Consolidated Essex County Council Drupal theme",
       "support": {
-        "source": "https://github.com/essexcountycouncil/ecc_theme/tree/1.0.17",
+        "source": "https://github.com/essexcountycouncil/ecc_theme/tree/1.0.18",
         "issues": "https://github.com/essexcountycouncil/ecc_theme/issues"
       },
-      "time": "2024-02-09T16:43:50+00:00"
+      "time": "2024-02-12T16:23:17+00:00"
     },
     {
       "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Bumps the shared theme version to 1.0.18.
## Call out any relevant implementation decisions
This removes the `grid-template-columns` property which was causing the massive gap between columns. See the shared theme [release](https://github.com/essexcountycouncil/ecc_theme/releases/tag/1.0.18).
## This PR has been tested in the following browsers
- [x] Arc