### PR TITLE
LP-88: Enable Tabs block. Revert frontpage node id.

### DIFF
--- a/config/default/block.block.ecc_theme_gov_localgov_tabs_scarfolk.yml
+++ b/config/default/block.block.ecc_theme_gov_localgov_tabs_scarfolk.yml
@@ -1,6 +1,6 @@
 uuid: 32e2a6e2-2ea5-4191-9e51-2f74de3706e9
 langcode: en
-status: false
+status: true
 dependencies:
   theme:
     - ecc_theme_gov

--- a/config/default/system.site.yml
+++ b/config/default/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: /node/1212
   404: /node/1212
-  front: /node/113
+  front: /node/1211
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Re-enable Tabs block (already enabled on Prod, missing from new theme)
![image](https://github.com/essexcountycouncil/essex-gov-uk-drupal/assets/56226/0f4dc77a-2643-4882-be73-82984f7a3065)

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
