### PR TITLE
Gitlab change to create tagged containers.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,9 +41,9 @@ build-and-push-images:
     - docker build -t ${DOCKER_REGISTRY}/portal-drupal-fpm -t ${DOCKER_REGISTRY}/portal-drupal-fpm${tag} -t portal-drupal-fpm -f Dockerfile-drupal .
     - docker build -t ${DOCKER_REGISTRY}/portal-nginx-drupal -t ${DOCKER_REGISTRY}/portal-nginx-drupal${tag} -t portal-nginx-drupal -f Dockerfile-nginx .
     - docker build -t ${DOCKER_REGISTRY}/portal-nginx-redirect -t ${DOCKER_REGISTRY}/portal-nginx-redirect${tag} -t portal-nginx-redirect -f Dockerfile-nginx-redirect .
-    - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal
-    - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm
-    - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect
+    - docker push ${DOCKER_REGISTRY}/portal-nginx-drupal$tag
+    - docker push ${DOCKER_REGISTRY}/portal-drupal-fpm$tag
+    - docker push ${DOCKER_REGISTRY}/portal-nginx-redirect$tag
 
 generate-sbom:
   stage: build


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Fix to allow deployment to Prod. My commit last month caused only the _latest_ tag container to be pushed to the Dev registry.

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
