### PR TITLE
updates pathauto settings for events, and events listing image style

### DIFF
--- a/config/default/pathauto.pattern.localgov_event.yml
+++ b/config/default/pathauto.pattern.localgov_event.yml
@@ -9,12 +9,12 @@ _core:
 id: localgov_event
 label: Event
 type: 'canonical_entities:node'
-pattern: 'events/[node:title]'
+pattern: 'children-young-people-and-families/fostering/events/[node:title]'
 selection_criteria:
-  29d4ed96-d72f-468e-9e44-f3c38f79cbcf:
+  1f812977-85ac-4c66-9e52-2973d3947b16:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 29d4ed96-d72f-468e-9e44-f3c38f79cbcf
+    uuid: 1f812977-85ac-4c66-9e52-2973d3947b16
     context_mapping:
       node: node
     bundles:

--- a/config/default/views.view.localgov_events_listing.yml
+++ b/config/default/views.view.localgov_events_listing.yml
@@ -34,6 +34,69 @@ display:
     display_options:
       title: Events
       fields:
+        localgov_event_image:
+          id: localgov_event_image
+          table: node__localgov_event_image
+          field: localgov_event_image
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_view
+          settings:
+            view_mode: localgov_event_thumbnail
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         title:
           id: title
           table: node_field_data
@@ -90,69 +153,6 @@ display:
           settings:
             link_to_entity: true
           group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        localgov_event_image:
-          id: localgov_event_image
-          table: node__localgov_event_image
-          field: localgov_event_image
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_entity_view
-          settings:
-            view_mode: localgov_event_thumbnail
-          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -1456,7 +1456,7 @@ display:
     display_options:
       exposed_block: true
       display_extenders: {  }
-      path: events
+      path: children-young-people-and-families/fostering/events
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/jira/software/projects/FOS/boards/24?assignee=557058%3A8b7fbfd8-fba0-4c51-bd41-0b1d0e7d6ebe&selectedIssue=FOS-61

- Sets pathauto settings for events to follow the fostering path (we'll be updating this again later to make it more generic)
- Adds image for events teasers for the events listing page
