### PR TITLE
Lp 94/breadcrumbs events listing page

### DIFF
--- a/config/default/block.block.ecc_theme_gov_breadcrumbs.yml
+++ b/config/default/block.block.ecc_theme_gov_breadcrumbs.yml
@@ -1,0 +1,25 @@
+uuid: a12bb938-e3e5-40f7-bbfe-8993a32dfe8f
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_classes
+    - system
+  theme:
+    - ecc_theme_gov
+id: ecc_theme_gov_breadcrumbs
+theme: ecc_theme_gov
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: 'Breadcrumbs - for views listing pages'
+  label_display: '0'
+  provider: system
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: "/events\r\n/children-young-people-and-families/fostering/events"

--- a/config/default/block.block.ecc_theme_gov_localgov_breadcrumbs_scarfolk.yml
+++ b/config/default/block.block.ecc_theme_gov_localgov_breadcrumbs_scarfolk.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - block_classes
     - node
     - system
   theme:
@@ -17,7 +18,7 @@ provider: null
 plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
-  label: Breadcrumbs
+  label: 'Breadcrumbs - for node pages'
   label_display: '0'
   provider: system
 visibility:

--- a/config/default/views.view.localgov_events_listing.yml
+++ b/config/default/views.view.localgov_events_listing.yml
@@ -1454,6 +1454,9 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      title: 'Fostering Events'
+      defaults:
+        title: false
       exposed_block: true
       display_extenders: {  }
       path: events


### PR DESCRIPTION
Fixes https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?label=ReleaseB&selectedIssue=LP-94

Two items here:
1. Adds breadcrumbs to the events listing page
2. Changes title of events listing page to 'Fostering events'