### PR TITLE
sets events listing image to use square_medium image style

### DIFF
--- a/config/default/views.view.localgov_events_listing.yml
+++ b/config/default/views.view.localgov_events_listing.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.body
     - field.storage.node.localgov_event_image
+    - image.style.square_medium
     - node.type.localgov_event
     - taxonomy.vocabulary.localgov_event_category
     - taxonomy.vocabulary.localgov_event_locality
@@ -12,6 +13,7 @@ dependencies:
   module:
     - date_recur
     - datetime
+    - media
     - node
     - taxonomy
     - text
@@ -149,9 +151,12 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_entity_view
+          type: media_thumbnail
           settings:
-            view_mode: localgov_event_thumbnail
+            image_link: ''
+            image_style: square_medium
+            image_loading:
+              attribute: lazy
           group_column: target_id
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
Fix for https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?label=ReleaseA&selectedIssue=LP-103

Sets images in the events listing view to use a square image style instead of a rendered view mode.