### PR TITLE
LP-118: Mail Login module, comment workflow fixes

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -18,6 +18,20 @@ jobs:
         with:
           creds: '{"clientId":"${{ vars.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ vars.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ vars.ARM_TENANT_ID }}"}'
 
+      - name: Deactivate revisions
+        id: deactivate
+        env:
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          REF_NAME: ${{ steps.comment-branch.outputs.head_ref }}
+        shell: bash
+        run: |
+          ENV_SLUG=$(echo "${REF_NAME}" | sed -e 's:[^[:alpha:]|^[:digit:]]:-:g' | sed -e 's/\(.*\)/\L\1/')
+          jq -n --argjson revisions $(az containerapp revision list -n portal -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)" | jq -c '[.[].name]') --argjson ingress $(az containerapp ingress show -n portal -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)"  | jq -c ".traffic | [.[].revisionName]") '{"revisions": $revisions, "ingress": $ingress} | .revisions-.ingress | .[]' | tr -d '"' | while read revision
+          do
+            echo Deactivating "$revision"
+            az containerapp revision deactivate --revision $revision -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)"
+          done
+
       - name: Deploy review app
         id: deploy
         env:

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -134,6 +134,16 @@ jobs:
         with:
           creds: '{"clientId":"${{ vars.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ vars.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ vars.ARM_TENANT_ID }}"}'
 
+      - name: Remove label
+        id: remove_label
+        env:
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          REF_NAME: ${{ steps.comment-branch.outputs.head_ref }}
+        run: |
+          ENV_SLUG=$(echo "${REF_NAME}" | sed -e 's:[^[:alpha:]|^[:digit:]]:-:g' | sed -e 's/\(.*\)/\L\1/')
+          az containerapp revision label remove --label ${ENV_SLUG} --name portal -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)"
+          sleep 1m
+
       - name: Deactivate revisions
         id: deactivate
         env:
@@ -163,47 +173,3 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             Stopped reviewapp
-
-  cleanup_reviewapp:
-    name: Cleanup reviewapp
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/cleanup')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get PR branch
-        uses: xt0rted/pull-request-comment-branch@v1
-        id: comment-branch
-
-      - name: Log in to Azure
-        uses: azure/login@v1
-        with:
-          creds: '{"clientId":"${{ vars.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ vars.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ vars.ARM_TENANT_ID }}"}'
-
-      - name: Deactivate revisions
-        id: deactivate
-        env:
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          REF_NAME: ${{ steps.comment-branch.outputs.head_ref }}
-        shell: bash
-        run: |
-          ENV_SLUG=$(echo "${REF_NAME}" | sed -e 's:[^[:alpha:]|^[:digit:]]:-:g' | sed -e 's/\(.*\)/\L\1/')
-          jq -n --argjson revisions $(az containerapp revision list -n portal -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)" | jq -c '[.[].name]') --argjson ingress $(az containerapp ingress show -n portal -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)"  | jq -c ".traffic | [.[].revisionName]") '{"revisions": $revisions, "ingress": $ingress} | .revisions-.ingress | .[]' | tr -d '"' | while read revision
-          do
-            echo Deactivating "$revision"
-            az containerapp revision deactivate --revision $revision -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)"
-          done
-
-      - name: Delete database
-        id: delete_db
-        env:
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
-          REF_NAME: ${{ steps.comment-branch.outputs.head_ref }}
-        run: |
-          ENV_SLUG=$(echo "${REF_NAME}" | sed -e 's:[^[:alpha:]|^[:digit:]]:-:g' | sed -e 's/\(.*\)/\L\1/')
-          az containerapp job start -n portal-dbclone -g rg-ecc-portal-uks-dev --subscription "Essex County Council (Portal)" --image "acreccuksdev.azurecr.io/dbclone" --env-vars "NEW_DB_SUFFIX=${ENV_SLUG}" "DESTROY_DB=1" 'MYSQL_HOST=mariadb-ecc-uks-dev.mariadb.database.azure.com' 'MYSQL_USER=mariadb-root' 'MYSQL_DATABASE=drupal_portal' 'MYSQL_PASSWORD=secretref:mysql-password' --container-name dbclonea --cpu 0.75 --memory 1.5
-
-      - name: Add comment
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Cleaned up reviewapp

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -107,7 +107,6 @@ jobs:
           EOF
           az containerapp revision copy -n portal -g rg-ecc-portal-uks-dev --yaml revision.yml --subscription "Essex County Council (Portal)" | tee revision.json 
           az containerapp revision label add --no-prompt -g rg-ecc-portal-uks-dev -n portal --label ${ENV_SLUG} --revision portal--gh${GITHUB_RUN_ID} --subscription "Essex County Council (Portal)"
-          az containerapp exec --command /drupal/deploy.sh -n portal --container drupal -g rg-ecc-portal-uks-dev
           echo "env_slug=${ENV_SLUG}" >> "$GITHUB_OUTPUT"
 
       - name: Drush deploy

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "drupal/health_check_url": "^3.2",
         "drupal/jsonapi_extras": "^3.24",
         "drupal/leaflet": "^10.2",
+        "drupal/mail_login": "^3.0",
         "drupal/migmag": "^1.8",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_process_markdown_to_html": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8528483fa82ac33beed697e1983ce6e8",
+    "content-hash": "d48e6f6fff91743e6e69ef8e4182cf46",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6204,6 +6204,62 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/linkit",
                 "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
+            "name": "drupal/mail_login",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/mail_login.git",
+                "reference": "3.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/mail_login-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "4c6ee7c42aa028d9c3fabefc8aba6482e10f5937"
+            },
+            "require": {
+                "drupal/core": "^9.1 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0",
+                    "datestamp": "1698852201",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Mohammad AlQanneh",
+                    "homepage": "https://www.drupal.org/u/mqanneh",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "mqanneh",
+                    "homepage": "https://www.drupal.org/user/2833163"
+                }
+            ],
+            "description": "This module enables users to login by email address.",
+            "homepage": "https://www.drupal.org/project/mail_login",
+            "keywords": [
+                "drupal",
+                "php",
+                "user"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/mail_login",
+                "issues": "http://drupal.org/project/issues/mail_login",
+                "email": "mqanneh@gmail.com"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -133,6 +133,7 @@ module:
   localgov_subsites_paragraphs: 0
   localgov_topics: 0
   localgov_workflows: 0
+  mail_login: 0
   media: 0
   media_library: 0
   media_library_edit: 0

--- a/config/default/mail_login.settings.yml
+++ b/config/default/mail_login.settings.yml
@@ -1,0 +1,15 @@
+_core:
+  default_config_hash: '-4lUZSCZBr1R5SJoy8mSXi6nMk2dC_0NWBoGSgDPAAI'
+mail_login_enabled: 1
+mail_login_case_sensitive: 1
+mail_login_email_only: 0
+mail_login_override_login_labels: 1
+mail_login_username_title: 'Login by username/email address'
+mail_login_username_description: 'You can use your username or email address to login.'
+mail_login_email_only_title: 'Login by email address'
+mail_login_email_only_description: 'You can use your email address only to login.'
+mail_login_password_only_description: 'Enter the password that accompanies your email address.'
+mail_login_password_reset_username_title: 'Username or email address'
+mail_login_password_reset_username_description: 'Password reset instructions will be sent to your registered email address.'
+mail_login_password_reset_email_only_title: 'Email address'
+mail_login_password_reset_email_only_description: 'Password reset instructions will be sent to your registered email address.'


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)

### Mail Login
Enable Mail Login module so that users on Review Apps and Preprod can login to a local account using their email address - Essex user names are pulled from AD and can be very long.

This does not affect Prod as the login page only has the _Log in with Essex_ button.

### Comment workflow fixes
- Add Remove Label step to stop_reviewapp. 
- Remove cleanup_reviewapp job (I can't remember why I thought we might need this as well as stop_reviewapp)
- Add Delete Revisions step to start_reviewapp job (just to remove any revisions that have been left running somehow)
- Remove deploy.sh step which doesn't work and is done properly in the next step

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
