### PR TITLE
FOS-141: Fixed events' breadcrumbs.

### DIFF
--- a/config/default/block.block.ecc_theme_gov_breadcrumbs.yml
+++ b/config/default/block.block.ecc_theme_gov_breadcrumbs.yml
@@ -22,4 +22,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "/events\r\n/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search"
+    pages: "/events\r\n/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search\r\n/essex-fostering/events\r\n/essex-fostering/events/search"

--- a/config/default/block.block.ecc_theme_gov_exposedformlocalgov_events_listingpage_all_events.yml
+++ b/config/default/block.block.ecc_theme_gov_exposedformlocalgov_events_listingpage_all_events.yml
@@ -26,4 +26,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search"
+    pages: "/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search\r\n/essex-fostering/events\r\n/essex-fostering/events/search"

--- a/config/default/block.block.ecc_theme_gov_exposedformlocalgov_events_searchevents_page.yml
+++ b/config/default/block.block.ecc_theme_gov_exposedformlocalgov_events_searchevents_page.yml
@@ -26,4 +26,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: "/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search"
+    pages: "/children-young-people-and-families/fostering/events\r\n/children-young-people-and-families/fostering/events/search\r\n/essex-fostering/events\r\n/essex-fostering/events/search"

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -39,6 +39,7 @@ module:
   ecc_cludo_search: 0
   ecc_content_moderation: 0
   ecc_cookie_compliance: 0
+  ecc_deploy: 0
   ecc_events: 0
   ecc_menu: 0
   ecc_subsites: 0

--- a/config/default/ecc_subsites.settings.yml
+++ b/config/default/ecc_subsites.settings.yml
@@ -1,2 +1,2 @@
-fostering_path: /children-young-people-and-families/fostering/events
+fostering_path: /essex-fostering
 fostering_homepage: 1884

--- a/config/default/google_tag.settings.yml
+++ b/config/default/google_tag.settings.yml
@@ -1,170 +1,39 @@
 _core:
   default_config_hash: R4IF-ClDHXxblLcG0L7MgsLvfBIMAvi_skumNFQwkDc
-module:
-  address: 0
-  admin_toolbar: 0
-  admin_toolbar_tools: 0
-  automated_cron: 0
-  block: 0
-  block_content: 0
-  breakpoint: 0
-  ckeditor: 0
-  ckeditor_div_manager: 0
-  cludo_search: 0
-  condition_field: 0
-  config: 0
-  content_moderation: 0
-  content_ownership: 0
-  contextual: 0
-  crop: 0
-  ctools: 0
-  date_recur: 0
-  date_recur_modular: 0
-  datetime: 0
-  datetime_range: 0
-  dbal: 0
-  dblog: 0
-  default_content: 0
-  diff: 0
-  dynamic_entity_reference: 0
-  dynamic_page_cache: 0
-  ecc_migrate: 0
-  editor: 0
-  entity_browser: 0
-  entity_browser_entity_form: 0
-  entity_hierarchy: 0
-  entity_hierarchy_breadcrumb: 0
-  entity_reference_facet_link: 0
-  entity_reference_revisions: 0
-  entity_usage: 0
-  eu_cookie_compliance_gtm: 0
-  facets: 0
-  field: 0
-  field_formatter_class: 0
-  field_group: 0
-  field_ui: 0
-  file: 0
-  filter: 0
-  fontawesome: 0
-  geocoder: 0
-  geocoder_field: 0
-  geocoder_geofield: 0
-  geofield: 0
-  geofield_map: 0
-  geolocation: 0
-  geolocation_google_maps: 0
-  google_tag: 0
-  gull_cookie_settings_block: 0
-  help: 0
-  history: 0
-  image: 0
-  image_widget_crop: 0
-  inline_entity_form: 0
-  inline_form_errors: 0
-  layout_discovery: 0
-  layout_paragraphs: 0
-  leaflet: 0
-  leaflet_views: 0
-  link: 0
-  link_attributes: 0
-  linkit: 0
-  localgov_admin_theme_improvements: 0
-  localgov_alert_banner: 0
-  localgov_core: 0
-  localgov_directories: 0
-  localgov_directories_db: 0
-  localgov_directories_location: 0
-  localgov_directories_org: 0
-  localgov_directories_page: 0
-  localgov_directories_promo_page: 0
-  localgov_directories_venue: 0
-  localgov_events: 0
-  localgov_forms: 0
-  localgov_geo: 0
-  localgov_geo_address: 0
-  localgov_geo_area: 0
-  localgov_guides: 0
-  localgov_homepage_paragraphs: 0
-  localgov_media: 0
-  localgov_menu_link_group: 0
-  localgov_news: 0
-  localgov_page_components: 0
-  localgov_paragraphs: 0
-  localgov_paragraphs_layout: 0
-  localgov_review_date: 0
-  localgov_roles: 0
-  localgov_search: 0
-  localgov_search_db: 0
-  localgov_services: 0
-  localgov_services_landing: 0
-  localgov_services_navigation: 0
-  localgov_services_page: 0
-  localgov_services_status: 0
-  localgov_services_sublanding: 0
-  localgov_step_by_step: 0
-  localgov_subsites: 0
-  localgov_subsites_paragraphs: 0
-  localgov_topics: 0
-  localgov_workflows: 0
-  media: 0
-  media_library: 0
-  menu_link_content: 0
-  menu_ui: 0
-  metatag: 0
-  migmag: 0
-  migmag_process: 0
-  migrate: 0
-  migrate_plus: 0
-  migrate_process_markdown_to_html: 0
-  mysql: 0
-  node: 0
-  office_hours: 0
-  openid_connect: 0
-  openid_connect_azure_b2c: 0
-  options: 0
-  page_cache: 0
-  paragraphs_library: 0
-  path: 0
-  path_alias: 0
-  permissions_filter: 0
-  preview_link: 0
-  redirect: 0
-  redirect_404: 0
-  responsive_image: 0
-  responsive_preview: 0
-  role_delegation: 0
-  scheduled_transitions: 0
-  schema_article: 0
-  schema_metatag: 0
-  search_api: 0
-  search_api_autocomplete: 0
-  search_api_db: 0
-  simple_sitemap: 0
-  system: 0
-  tablefield: 0
-  taxonomy: 0
-  telephone: 0
-  text: 0
-  token: 0
-  toolbar: 0
-  update: 0
-  user: 0
-  views_ui: 0
-  viewsreference: 0
-  webform: 0
-  webform_ui: 0
-  workflows: 0
-  pathauto: 1
-  externalauth: 10
-  views: 10
-  paragraphs: 11
-  localgov: 1000
-  eu_cookie_compliance: 1001
-theme:
-  claro: 0
-  stable: 0
-  gin: 0
-  localgov_base: 0
-  localgov_scarfolk: 0
-  essex: 0
-profile: localgov
+uri: 'public:/'
+compact_snippet: true
+include_file: true
+rebuild_snippets: true
+flush_snippets: false
+debug_output: false
+_default_container:
+  container_id: ecc_public
+  data_layer: dataLayer
+  include_classes: false
+  whitelist_classes: |-
+    google
+    nonGooglePixels
+    nonGoogleScripts
+    nonGoogleIframes
+  blacklist_classes: |-
+    customScripts
+    customPixels
+  include_environment: false
+  environment_id: ''
+  environment_token: ''
+  path_toggle: 'exclude listed'
+  path_list: |-
+    /admin*
+    /batch*
+    /node/add*
+    /node/*/edit
+    /node/*/delete
+    /user/*/edit*
+    /user/*/cancel*
+  role_toggle: 'exclude listed'
+  role_list: {  }
+  status_toggle: 'exclude listed'
+  status_list: |-
+    403
+    404
+default_google_tag_entity: ecc_public

--- a/config/default/pathauto.pattern.localgov_event.yml
+++ b/config/default/pathauto.pattern.localgov_event.yml
@@ -9,12 +9,12 @@ _core:
 id: localgov_event
 label: Event
 type: 'canonical_entities:node'
-pattern: 'children-young-people-and-families/fostering/events/[node:title]'
+pattern: 'essex-fostering/events/[node:title]'
 selection_criteria:
-  1f812977-85ac-4c66-9e52-2973d3947b16:
+  dcb2841c-2170-4937-8333-e91597bc709c:
     id: 'entity_bundle:node'
     negate: false
-    uuid: 1f812977-85ac-4c66-9e52-2973d3947b16
+    uuid: dcb2841c-2170-4937-8333-e91597bc709c
     context_mapping:
       node: node
     bundles:

--- a/config/default/preview_link.settings.yml
+++ b/config/default/preview_link.settings.yml
@@ -3,5 +3,5 @@ _core:
 display_message: subsequent
 enabled_entity_types: {  }
 multiple_entities: false
-expiry_seconds: 2592000
-expiry_entry_in_days: true
+expiry_seconds: 7776000
+expiry_entry_in_days: false

--- a/config/default/views.view.localgov_events_listing.yml
+++ b/config/default/views.view.localgov_events_listing.yml
@@ -1454,7 +1454,7 @@ display:
         title: false
       exposed_block: true
       display_extenders: {  }
-      path: children-young-people-and-families/fostering/events
+      path: essex-fostering/events
       menu:
         type: none
         title: Events

--- a/config/default/views.view.localgov_events_search.yml
+++ b/config/default/views.view.localgov_events_search.yml
@@ -263,7 +263,7 @@ display:
         cache: false
       exposed_block: true
       display_extenders: {  }
-      path: children-young-people-and-families/fostering/events/search
+      path: essex-fostering/events/search
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/ecc_deploy/ecc_deploy.deploy.php
+++ b/web/modules/custom/ecc_deploy/ecc_deploy.deploy.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @file
+ * Deploy functions for the Essex .GOV deploy module.
+ */
+
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+
+/**
+ * Deploy hook to update menu item paths.
+ */
+function ecc_deploy_deploy_menu_paths_001(&$sandbox) {
+  // The pattern below will be used in hook_update_N FNs in subsequent
+  // deployments, when the need to update menu items are required.
+  // If the routes don't yet exist prior to the deployment, such as the case
+  // when a view's path is updated, this is the place to do the menu updates.
+  $menu_updates = [
+    [
+      'menu_name' => 'subsites',
+      'old_path' => '/children-young-people-and-families/fostering/events',
+      'new_path' => '/essex-fostering/events',
+    ],
+    [
+      'menu_name' => 'subsites',
+      'old_path' => '/children-young-people-and-families/fostering/events/search',
+      'new_path' => '/essex-fostering/events/search',
+    ],
+  ];
+
+  foreach ($menu_updates as $update) {
+    // Load the menu link by its path.
+    $query = \Drupal::entityTypeManager()->getStorage('menu_link_content')->getQuery();
+    $query->condition('menu_name', $update['menu_name']);
+    $query->condition('link__uri', 'internal:' . $update['old_path']);
+    $query->accessCheck(FALSE);
+    $result = $query->execute();
+
+    if (!empty($result)) {
+      // Load the menu link entity.
+      $menu_link_id = reset($result);
+      $menu_link = MenuLinkContent::load($menu_link_id);
+
+      if ($menu_link) {
+        // Update the link path.
+        $menu_link->set('link', ['uri' => 'internal:' . $update['new_path']]);
+        $menu_link->save();
+
+        \Drupal::messenger()->addMessage(t('The menu item path has been updated from %old_path to %new_path.', [
+          '%old_path' => $update['old_path'],
+          '%new_path' => $update['new_path'],
+        ]));
+      }
+      else {
+        \Drupal::messenger()->addWarning(t('Menu link entity could not be loaded for %old_path.', [
+          '%old_path' => $update['old_path'],
+        ]));
+      }
+    }
+    else {
+      \Drupal::messenger()->addWarning(t('No menu link found with the path %old_path.', [
+        '%old_path' => $update['old_path'],
+      ]));
+    }
+  }
+
+}

--- a/web/modules/custom/ecc_deploy/ecc_deploy.info.yml
+++ b/web/modules/custom/ecc_deploy/ecc_deploy.info.yml
@@ -1,0 +1,5 @@
+name: 'Essex .GOV deploy'
+type: module
+description: 'Runs tasks primarily with hook_update_N.'
+package: Custom
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/ecc_deploy/ecc_deploy.install
+++ b/web/modules/custom/ecc_deploy/ecc_deploy.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the Essex .GOV deploy module.
+ */

--- a/web/modules/custom/ecc_subsites/config/install/ecc_subsites.settings.yml
+++ b/web/modules/custom/ecc_subsites/config/install/ecc_subsites.settings.yml
@@ -1,2 +1,2 @@
-fostering_path: /fostering
+fostering_path: /essex-fostering
 fostering_homepage: 1884


### PR DESCRIPTION
## Prep for fostering go live

- views paths updated
- relevant blocks' "restricted to" paths updated
- pathauto patterns updated
- ecc_subsite's path updated
- `ecc_deploy` module added to do automated content updates when needed (in this case, updating a couple of menu paths).
- fixed google_tag settings and updated preview_link settings