### PR TITLE
LP-144: Update localgov packages, ensuring localgov_alert_banner upda…

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10921,16 +10921,16 @@
         },
         {
             "name": "localgovdrupal/localgov",
-            "version": "3.0.5",
+            "version": "3.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov.git",
-                "reference": "f8d64ef8626620dc6d80de81459b3b9a4301c32f"
+                "reference": "81086297cf34dc6cf13c3a6ba4bb7e2866623e6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov/zipball/f8d64ef8626620dc6d80de81459b3b9a4301c32f",
-                "reference": "f8d64ef8626620dc6d80de81459b3b9a4301c32f",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov/zipball/81086297cf34dc6cf13c3a6ba4bb7e2866623e6e",
+                "reference": "81086297cf34dc6cf13c3a6ba4bb7e2866623e6e",
                 "shasum": ""
             },
             "require": {
@@ -10942,6 +10942,7 @@
                 "drupal/gin_login": "^2.0.3",
                 "drupal/gin_toolbar": "^1.0@beta",
                 "drupal/preview_link": "^2.1@alpha",
+                "drupal/redirect": "^1.6",
                 "drupal/search_api": "^1.21",
                 "drupal/simple_sitemap": "^4.1",
                 "drush/drush": ">=10",
@@ -10978,6 +10979,13 @@
                 "patches": {
                     "drupal/core": {
                         "Users can't reference unpublished content even when they have access to it. See https://www.drupal.org/project/drupal/issues/2845144": "https://www.drupal.org/files/issues/2024-02-13/2845144-87.patch"
+                    },
+                    "drupal/preview_link": {
+                        "Automatically populating multiple preview link entities #3439968": "https://www.drupal.org/files/issues/2024-05-22/3439968-4.diff",
+                        "Add a 'copy to clipboard' feature for preview_link": "https://www.drupal.org/files/issues/2024-05-28/3449121-9.patch"
+                    },
+                    "drupal/redirect": {
+                        "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2022-09-01/3057250-53.patch"
                     }
                 }
             },
@@ -10989,22 +10997,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov/issues",
-                "source": "https://github.com/localgovdrupal/localgov/tree/3.0.5"
+                "source": "https://github.com/localgovdrupal/localgov/tree/3.0.7"
             },
-            "time": "2024-05-21T12:54:52+00:00"
+            "time": "2024-06-19T13:49:11+00:00"
         },
         {
             "name": "localgovdrupal/localgov_alert_banner",
-            "version": "1.7.6",
+            "version": "1.7.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_alert_banner.git",
-                "reference": "25fb41200be847e6b6ff98fb02dc9dad64d8667a"
+                "reference": "4b9d451e4298cb87fc542de1060cb778673e2b66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_alert_banner/zipball/25fb41200be847e6b6ff98fb02dc9dad64d8667a",
-                "reference": "25fb41200be847e6b6ff98fb02dc9dad64d8667a",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_alert_banner/zipball/4b9d451e4298cb87fc542de1060cb778673e2b66",
+                "reference": "4b9d451e4298cb87fc542de1060cb778673e2b66",
                 "shasum": ""
             },
             "require": {
@@ -11029,9 +11037,9 @@
             "homepage": "https://github.com/localgovdrupal/localgov_alert_banner",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_alert_banner/issues",
-                "source": "https://github.com/localgovdrupal/localgov_alert_banner/tree/1.7.6"
+                "source": "https://github.com/localgovdrupal/localgov_alert_banner/tree/1.7.8"
             },
-            "time": "2024-05-21T12:20:59+00:00"
+            "time": "2024-06-13T15:04:31+00:00"
         },
         {
             "name": "localgovdrupal/localgov_base",
@@ -11093,16 +11101,16 @@
         },
         {
             "name": "localgovdrupal/localgov_core",
-            "version": "2.13.1",
+            "version": "2.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_core.git",
-                "reference": "fc933f93617a5a2d871eb2d2e0989f42a8b97e50"
+                "reference": "845651fca98ea77b72f2f06dd0cc3d8aa563638b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_core/zipball/fc933f93617a5a2d871eb2d2e0989f42a8b97e50",
-                "reference": "fc933f93617a5a2d871eb2d2e0989f42a8b97e50",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_core/zipball/845651fca98ea77b72f2f06dd0cc3d8aa563638b",
+                "reference": "845651fca98ea77b72f2f06dd0cc3d8aa563638b",
                 "shasum": ""
             },
             "require": {
@@ -11112,7 +11120,6 @@
                 "drupal/media_library_edit": "^3.0",
                 "drupal/metatag": "^1.14",
                 "drupal/pathauto": "^1.8",
-                "drupal/redirect": "^1.6",
                 "drupal/role_delegation": "^1.1",
                 "drupal/token": "^1.7"
             },
@@ -11122,11 +11129,6 @@
             "type": "drupal-module",
             "extra": {
                 "enable-patching": true,
-                "patches": {
-                    "drupal/redirect": {
-                        "Validation issue on adding url redirect: https://www.drupal.org/project/redirect/issues/3057250": "https://www.drupal.org/files/issues/2022-09-01/3057250-53.patch"
-                    }
-                },
                 "composer-exit-on-patch-failure": true,
                 "patchLevel": {
                     "drupal/core": "-p2"
@@ -11140,22 +11142,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov_core",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_core/issues",
-                "source": "https://github.com/localgovdrupal/localgov_core/tree/2.13.1"
+                "source": "https://github.com/localgovdrupal/localgov_core/tree/2.13.3"
             },
-            "time": "2024-03-19T12:04:51+00:00"
+            "time": "2024-06-13T15:04:56+00:00"
         },
         {
             "name": "localgovdrupal/localgov_demo",
-            "version": "3.0.0-alpha2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_demo.git",
-                "reference": "71b96d355ee245ac21bb40cbc823203f75ea5a79"
+                "reference": "20dc90b1edae7d91a17c0f29d19443d8e5728b69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_demo/zipball/71b96d355ee245ac21bb40cbc823203f75ea5a79",
-                "reference": "71b96d355ee245ac21bb40cbc823203f75ea5a79",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_demo/zipball/20dc90b1edae7d91a17c0f29d19443d8e5728b69",
+                "reference": "20dc90b1edae7d91a17c0f29d19443d8e5728b69",
                 "shasum": ""
             },
             "require": {
@@ -11166,6 +11168,7 @@
                 "localgovdrupal/localgov_events": "^3.0@alpha",
                 "localgovdrupal/localgov_guides": "^2.1",
                 "localgovdrupal/localgov_news": "^2.3",
+                "localgovdrupal/localgov_publications": "^1.0",
                 "localgovdrupal/localgov_search": "^1.2",
                 "localgovdrupal/localgov_services": "^2.1",
                 "localgovdrupal/localgov_step_by_step": "^2.1",
@@ -11181,22 +11184,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov_demo",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_demo/issues",
-                "source": "https://github.com/localgovdrupal/localgov_demo/tree/3.0.0-alpha2"
+                "source": "https://github.com/localgovdrupal/localgov_demo/tree/3.0.0"
             },
-            "time": "2023-09-04T13:46:20+00:00"
+            "time": "2024-06-18T12:13:43+00:00"
         },
         {
             "name": "localgovdrupal/localgov_directories",
-            "version": "3.1.5",
+            "version": "3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_directories.git",
-                "reference": "428a635281afea302140699f242d790627e7a479"
+                "reference": "b49dc726fa9951f83481c073e0483f734046f8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_directories/zipball/428a635281afea302140699f242d790627e7a479",
-                "reference": "428a635281afea302140699f242d790627e7a479",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_directories/zipball/b49dc726fa9951f83481c073e0483f734046f8dd",
+                "reference": "b49dc726fa9951f83481c073e0483f734046f8dd",
                 "shasum": ""
             },
             "require": {
@@ -11204,7 +11207,7 @@
                 "drupal/pathauto": "^1.6",
                 "drupal/search_api": "^1.29",
                 "drupal/search_api_autocomplete": "^1.3",
-                "drupal/search_api_location": "1.x-dev",
+                "drupal/search_api_location": "1.x-dev#cf3e546770099b1f136c020ade79a650d4178ad6",
                 "localgovdrupal/localgov_core": "^2.12",
                 "localgovdrupal/localgov_geo": "^2.0"
             },
@@ -11233,9 +11236,9 @@
             "homepage": "https://github.com/localgovdrupal/localgov_directories",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_directories/issues",
-                "source": "https://github.com/localgovdrupal/localgov_directories/tree/3.1.5"
+                "source": "https://github.com/localgovdrupal/localgov_directories/tree/3.1.7"
             },
-            "time": "2024-03-12T13:06:09+00:00"
+            "time": "2024-06-18T12:01:11+00:00"
         },
         {
             "name": "localgovdrupal/localgov_eu_cookie_compliance",
@@ -11355,16 +11358,16 @@
         },
         {
             "name": "localgovdrupal/localgov_geo",
-            "version": "2.0.3",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_geo.git",
-                "reference": "87d7e3ef417afdef8e6822b5f6f7f9d27c33e42d"
+                "reference": "5cdbfde97a526ad24076b8cc7cb090f2e4dd88ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_geo/zipball/87d7e3ef417afdef8e6822b5f6f7f9d27c33e42d",
-                "reference": "87d7e3ef417afdef8e6822b5f6f7f9d27c33e42d",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_geo/zipball/5cdbfde97a526ad24076b8cc7cb090f2e4dd88ec",
+                "reference": "5cdbfde97a526ad24076b8cc7cb090f2e4dd88ec",
                 "shasum": ""
             },
             "require": {
@@ -11385,22 +11388,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov_geo",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_geo/issues",
-                "source": "https://github.com/localgovdrupal/localgov_geo/tree/2.0.3"
+                "source": "https://github.com/localgovdrupal/localgov_geo/tree/2.0.6"
             },
-            "time": "2024-04-30T11:43:26+00:00"
+            "time": "2024-06-18T12:29:34+00:00"
         },
         {
             "name": "localgovdrupal/localgov_guides",
-            "version": "2.1.9",
+            "version": "2.1.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_guides.git",
-                "reference": "6bc15575a35cd4927ae523aaa07e7114d9b336a7"
+                "reference": "70c73de75dd1def8624c7442c4c24c8f413b546f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_guides/zipball/6bc15575a35cd4927ae523aaa07e7114d9b336a7",
-                "reference": "6bc15575a35cd4927ae523aaa07e7114d9b336a7",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_guides/zipball/70c73de75dd1def8624c7442c4c24c8f413b546f",
+                "reference": "70c73de75dd1def8624c7442c4c24c8f413b546f",
                 "shasum": ""
             },
             "require": {
@@ -11420,22 +11423,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov_guides",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_guides/issues",
-                "source": "https://github.com/localgovdrupal/localgov_guides/tree/2.1.9"
+                "source": "https://github.com/localgovdrupal/localgov_guides/tree/2.1.10"
             },
-            "time": "2024-05-14T11:21:06+00:00"
+            "time": "2024-06-18T12:10:21+00:00"
         },
         {
             "name": "localgovdrupal/localgov_menu_link_group",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_menu_link_group.git",
-                "reference": "a9aac36cd3932d2cb120ab6f3476dfba1c98730f"
+                "reference": "ccee8849311223f41e7c14b80388e80f0bb07030"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_menu_link_group/zipball/a9aac36cd3932d2cb120ab6f3476dfba1c98730f",
-                "reference": "a9aac36cd3932d2cb120ab6f3476dfba1c98730f",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_menu_link_group/zipball/ccee8849311223f41e7c14b80388e80f0bb07030",
+                "reference": "ccee8849311223f41e7c14b80388e80f0bb07030",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -11447,9 +11450,9 @@
             "homepage": "https://github.com/localgovdrupal/localgov_menu_link_group",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_menu_link_group/issues",
-                "source": "https://github.com/localgovdrupal/localgov_menu_link_group/tree/1.1.3"
+                "source": "https://github.com/localgovdrupal/localgov_menu_link_group/tree/1.1.4"
             },
-            "time": "2024-03-05T12:49:58+00:00"
+            "time": "2024-05-29T10:51:58+00:00"
         },
         {
             "name": "localgovdrupal/localgov_news",
@@ -11614,16 +11617,16 @@
         },
         {
             "name": "localgovdrupal/localgov_paragraphs",
-            "version": "2.4.3",
+            "version": "2.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_paragraphs.git",
-                "reference": "75e2455896247ac5fe50a8cd7cf2b23ab8e98daf"
+                "reference": "f85e9be7c5421ff2c23cf2ac3af8c211ead2625e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_paragraphs/zipball/75e2455896247ac5fe50a8cd7cf2b23ab8e98daf",
-                "reference": "75e2455896247ac5fe50a8cd7cf2b23ab8e98daf",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_paragraphs/zipball/f85e9be7c5421ff2c23cf2ac3af8c211ead2625e",
+                "reference": "f85e9be7c5421ff2c23cf2ac3af8c211ead2625e",
                 "shasum": ""
             },
             "require": {
@@ -11657,9 +11660,6 @@
                     },
                     "drupal/tablefield": {
                         "Fix PHP8.2 deprecation in Drupal tablefield, see https://www.drupal.org/project/tablefield/issues/3397688.": "https://www.drupal.org/files/issues/2023-12-21/tablefield-php8.2-deprecated-creation-of-dynamic-properties-3397688-9.patch"
-                    },
-                    "drupal/viewsreference": {
-                        "Fix schema #2957529": "https://www.drupal.org/files/issues/2022-07-06/viewsreference_schema-2957529-13.patch"
                     }
                 }
             },
@@ -11671,9 +11671,50 @@
             "homepage": "https://github.com/localgovdrupal/localgov_paragraphs",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_paragraphs/issues",
-                "source": "https://github.com/localgovdrupal/localgov_paragraphs/tree/2.4.3"
+                "source": "https://github.com/localgovdrupal/localgov_paragraphs/tree/2.4.5"
             },
-            "time": "2024-04-18T22:39:54+00:00"
+            "time": "2024-06-13T15:05:39+00:00"
+        },
+        {
+            "name": "localgovdrupal/localgov_publications",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localgovdrupal/localgov_publications.git",
+                "reference": "c7449ce44e73ddaf5351b31f7287757abfd6fc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_publications/zipball/c7449ce44e73ddaf5351b31f7287757abfd6fc67",
+                "reference": "c7449ce44e73ddaf5351b31f7287757abfd6fc67",
+                "shasum": ""
+            },
+            "require": {
+                "localgovdrupal/localgov_core": ">=2.1.10",
+                "localgovdrupal/localgov_paragraphs": ">=2.4.0"
+            },
+            "require-dev": {
+                "drupal/coder": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "installer-paths": {
+                    "web/libraries/{$name}": [
+                        "type:drupal-library"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "HTML publications for the LocalGovDrupal distribution.",
+            "homepage": "https://github.com/localgovdrupal/localgov_publications",
+            "support": {
+                "issues": "https://github.com/localgovdrupal/localgov_publications/issues",
+                "source": "https://github.com/localgovdrupal/localgov_publications/tree/1.0.3"
+            },
+            "time": "2024-06-18T11:49:16+00:00"
         },
         {
             "name": "localgovdrupal/localgov_scarfolk",
@@ -11740,16 +11781,16 @@
         },
         {
             "name": "localgovdrupal/localgov_services",
-            "version": "2.1.10",
+            "version": "2.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_services.git",
-                "reference": "a07a6a9248e94e81950fd7eeaabf5655cce12146"
+                "reference": "afb0e907ffd426028a8d3875bd16149724b0517f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_services/zipball/a07a6a9248e94e81950fd7eeaabf5655cce12146",
-                "reference": "a07a6a9248e94e81950fd7eeaabf5655cce12146",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_services/zipball/afb0e907ffd426028a8d3875bd16149724b0517f",
+                "reference": "afb0e907ffd426028a8d3875bd16149724b0517f",
                 "shasum": ""
             },
             "require": {
@@ -11780,22 +11821,22 @@
             "homepage": "https://github.com/localgovdrupal/localgov_services",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_services/issues",
-                "source": "https://github.com/localgovdrupal/localgov_services/tree/2.1.10"
+                "source": "https://github.com/localgovdrupal/localgov_services/tree/2.1.11"
             },
-            "time": "2024-05-14T11:47:38+00:00"
+            "time": "2024-06-18T12:08:43+00:00"
         },
         {
             "name": "localgovdrupal/localgov_step_by_step",
-            "version": "2.1.5",
+            "version": "2.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_step_by_step.git",
-                "reference": "7e0b21fcd2628d9ee4bc2e54269f9a7310ca1a52"
+                "reference": "be8edf3548693a8e863c71d67f91aaa7f6e4034e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_step_by_step/zipball/7e0b21fcd2628d9ee4bc2e54269f9a7310ca1a52",
-                "reference": "7e0b21fcd2628d9ee4bc2e54269f9a7310ca1a52",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_step_by_step/zipball/be8edf3548693a8e863c71d67f91aaa7f6e4034e",
+                "reference": "be8edf3548693a8e863c71d67f91aaa7f6e4034e",
                 "shasum": ""
             },
             "require": {
@@ -11815,9 +11856,9 @@
             "homepage": "https://github.com/localgovdrupal/localgov_step_by_step",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_step_by_step/issues",
-                "source": "https://github.com/localgovdrupal/localgov_step_by_step/tree/2.1.5"
+                "source": "https://github.com/localgovdrupal/localgov_step_by_step/tree/2.1.6"
             },
-            "time": "2024-03-05T12:50:06+00:00"
+            "time": "2024-06-18T12:10:53+00:00"
         },
         {
             "name": "localgovdrupal/localgov_subsites",
@@ -11866,12 +11907,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_subsites_extras.git",
-                "reference": "d8c324bc7fa69855d929e6bd03ee1482ff6de700"
+                "reference": "2b61f1ef6d073196bdaf6feeafc0a0b0e4e2f46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_subsites_extras/zipball/d8c324bc7fa69855d929e6bd03ee1482ff6de700",
-                "reference": "d8c324bc7fa69855d929e6bd03ee1482ff6de700",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_subsites_extras/zipball/2b61f1ef6d073196bdaf6feeafc0a0b0e4e2f46f",
+                "reference": "2b61f1ef6d073196bdaf6feeafc0a0b0e4e2f46f",
                 "shasum": ""
             },
             "default-branch": true,
@@ -11886,7 +11927,7 @@
                 "issues": "https://github.com/localgovdrupal/localgov_subsites_extras/issues",
                 "source": "https://github.com/localgovdrupal/localgov_subsites_extras/tree/1.x"
             },
-            "time": "2024-05-17T15:30:31+00:00"
+            "time": "2024-05-29T09:50:19+00:00"
         },
         {
             "name": "localgovdrupal/localgov_topics",
@@ -11917,16 +11958,16 @@
         },
         {
             "name": "localgovdrupal/localgov_workflows",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localgovdrupal/localgov_workflows.git",
-                "reference": "c0653125bcb2523a1b46236def4f62bca12b0ba7"
+                "reference": "449285d625601f044f799436070ede6acd9d1e73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localgovdrupal/localgov_workflows/zipball/c0653125bcb2523a1b46236def4f62bca12b0ba7",
-                "reference": "c0653125bcb2523a1b46236def4f62bca12b0ba7",
+                "url": "https://api.github.com/repos/localgovdrupal/localgov_workflows/zipball/449285d625601f044f799436070ede6acd9d1e73",
+                "reference": "449285d625601f044f799436070ede6acd9d1e73",
                 "shasum": ""
             },
             "require": {
@@ -11945,9 +11986,9 @@
             "homepage": "https://github.com/localgovdrupal/localgov_workflows",
             "support": {
                 "issues": "https://github.com/localgovdrupal/localgov_workflows/issues",
-                "source": "https://github.com/localgovdrupal/localgov_workflows/tree/1.3.3"
+                "source": "https://github.com/localgovdrupal/localgov_workflows/tree/1.3.4"
             },
-            "time": "2024-05-21T12:15:55+00:00"
+            "time": "2024-06-13T14:59:51+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
…te to 1.7.8

## Include a summary of what this merge request involves (*)
Currently it looks like Alert banners are broken on live due to caching issues which have been flagged on https://github.com/localgovdrupal/localgov_alert_banner/issues/327

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
