### PR TITLE
Add top tasks field to subsite overview pages content type. LP-120.

### DIFF
--- a/config/default/core.entity_form_display.node.localgov_subsites_overview.default.yml
+++ b/config/default/core.entity_form_display.node.localgov_subsites_overview.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -15,6 +16,7 @@ dependencies:
     - content_moderation
     - field_group
     - layout_paragraphs
+    - link
     - localgov_review_date
     - paragraphs
     - path
@@ -24,11 +26,12 @@ third_party_settings:
       children:
         - group_description
         - group_banner
+        - group_top_tasks
         - group_page_builder
       label: tabs
       region: content
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: tabs
       format_settings:
         classes: ''
@@ -72,7 +75,7 @@ third_party_settings:
       label: 'Page builder'
       region: content
       parent_name: group_tabs
-      weight: 11
+      weight: 12
       format_type: tab
       format_settings:
         classes: ''
@@ -80,6 +83,21 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: false
+    group_top_tasks:
+      children:
+        - localgov_common_tasks
+      label: 'Top Tasks'
+      region: hidden
+      parent_name: group_tabs
+      weight: 11
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        formatter: closed
+        description: ''
+        required_fields: true
 _core:
   default_config_hash: '-V75HtvAEZSjGucowfDpfF8Lk30I4MqxR0nqSx05sQw'
 id: node.localgov_subsites_overview.default
@@ -93,9 +111,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  localgov_common_tasks:
+    type: link_default
+    weight: 42
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   localgov_review_date:
     type: review_date
-    weight: 0
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -123,7 +149,7 @@ content:
     third_party_settings: {  }
   localgov_subsites_content:
     type: layout_paragraphs
-    weight: 34
+    weight: 9
     region: content
     settings:
       preview_view_mode: default
@@ -160,7 +186,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -178,7 +204,7 @@ content:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -191,7 +217,7 @@ content:
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 8
+    weight: 9
     region: content
     settings:
       display_label: true
@@ -215,7 +241,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -32,6 +33,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_common_tasks: true
   localgov_services_parent: true
   localgov_subsites_banner: true
   localgov_subsites_hide_menu: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.grid_item.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.grid_item.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.grid_item
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -30,6 +31,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_common_tasks: true
   localgov_services_parent: true
   localgov_subsites_banner: true
   localgov_subsites_content: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.search_index.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -13,6 +14,7 @@ dependencies:
     - node.type.localgov_subsites_overview
   module:
     - layout_paragraphs
+    - link
     - user
 _core:
   default_config_hash: I3klntxojCjVS2TSj7gM8E5rX1ZUmzPAT6TNSnZ_3NA
@@ -21,6 +23,18 @@ targetEntityType: node
 bundle: localgov_subsites_overview
 mode: search_index
 content:
+  localgov_common_tasks:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 12
+    region: content
   localgov_subsites_content:
     type: layout_paragraphs
     label: hidden

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -30,6 +31,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_common_tasks: true
   localgov_services_parent: true
   localgov_subsites_banner: true
   localgov_subsites_content: true

--- a/config/default/core.entity_view_display.node.localgov_subsites_overview.teaser.yml
+++ b/config/default/core.entity_view_display.node.localgov_subsites_overview.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.localgov_subsites_overview.localgov_common_tasks
     - field.field.node.localgov_subsites_overview.localgov_services_parent
     - field.field.node.localgov_subsites_overview.localgov_subsites_banner
     - field.field.node.localgov_subsites_overview.localgov_subsites_content
@@ -30,6 +31,7 @@ content:
 hidden:
   content_moderation_control: true
   links: true
+  localgov_common_tasks: true
   localgov_services_parent: true
   localgov_subsites_banner: true
   localgov_subsites_content: true

--- a/config/default/field.field.node.localgov_subsites_overview.localgov_common_tasks.yml
+++ b/config/default/field.field.node.localgov_subsites_overview.localgov_common_tasks.yml
@@ -1,0 +1,23 @@
+uuid: 7fb952bb-6e9c-4780-9c5c-9e666982e145
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_common_tasks
+    - node.type.localgov_subsites_overview
+  module:
+    - link
+id: node.localgov_subsites_overview.localgov_common_tasks
+field_name: localgov_common_tasks
+entity_type: node
+bundle: localgov_subsites_overview
+label: 'Top tasks'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link


### PR DESCRIPTION
Adds top tasks (localgov_common_tasks field) to subsite overview page content type.
Config only.
Thankfully, when comparing rendered output to a service landing page, the styles seem to just work.

https://eccservicetransformation.atlassian.net/browse/LP-120

Steps to test:

1. Find a service landing page, e.g. `/node/1657` and add some top tasks and save, to see what the goal is.
2. Find a subsite overview page, e.g. `node/1476` and edit.
3. Verify that top tasks is a tab, and allows you to enter links. Save the node.
4. Verify that the output matches the service landing page output for top tasks.