### PR TITLE
202408 formprotection lp 119

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         "drupal/gin": "^3.0@RC",
         "drupal/google_tag": "^1.6",
         "drupal/health_check_url": "^3.2",
+        "drupal/honeypot": "^2.1",
         "drupal/jsonapi_extras": "^3.24",
         "drupal/leaflet": "^10.2",
         "drupal/mail_login": "^3.0",
@@ -195,6 +196,9 @@
             },
             "localgovdrupal/localgov_workflows": {
                 "Fix for drush site-install": "patches/localgov_workflows.patch"
+            },
+            "drupal/honeypot": {
+              "honeypot clientside": "https://www.drupal.org/files/issues/2024-08-16/clientside_time_limit_2_1_4.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "ckeditor/div": "4.10.1",
         "composer/installers": "^1.10",
         "cweagans/composer-patches": "^1.6",
+        "drupal/antibot": "^2.0",
         "drupal/autosave_form": "^1.4",
         "drupal/block_classes": "^1.0",
         "drupal/ckeditor5_show_block": "^1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bca341cedbb3c14fa3ad2561dc4316b",
+    "content-hash": "f3ac6b0d26930435fe04b38cd107c4fd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2321,6 +2321,58 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
+            }
+        },
+        {
+            "name": "drupal/antibot",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/antibot.git",
+                "reference": "2.0.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/antibot-2.0.3.zip",
+                "reference": "2.0.3",
+                "shasum": "b26b603299ee3067e0aa3875ff752815f21d2f0b"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.3",
+                    "datestamp": "1708358087",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "danrod",
+                    "homepage": "https://www.drupal.org/user/19150"
+                },
+                {
+                    "name": "gaurav.kapoor",
+                    "homepage": "https://www.drupal.org/user/3495331"
+                },
+                {
+                    "name": "mstef",
+                    "homepage": "https://www.drupal.org/user/107190"
+                }
+            ],
+            "description": "Prevent forms from being submitted without JavaScript enabled.",
+            "homepage": "https://www.drupal.org/project/antibot",
+            "support": {
+                "source": "https://git.drupalcode.org/project/antibot"
             }
         },
         {
@@ -5594,6 +5646,75 @@
             "homepage": "https://www.drupal.org/project/health_check_url",
             "support": {
                 "source": "https://git.drupalcode.org/project/health_check_url"
+            }
+        },
+        {
+            "name": "drupal/honeypot",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/honeypot.git",
+                "reference": "2.1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.4.zip",
+                "reference": "2.1.4",
+                "shasum": "adf76c3520c0e458177dbe6d638aa2d6ae40a95b"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/rules": "^3.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.1.4",
+                    "datestamp": "1723489062",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Geerling",
+                    "homepage": "https://www.drupal.org/user/389011",
+                    "email": "geerlingguy@mac.com"
+                },
+                {
+                    "name": "Manuel Garcia",
+                    "homepage": "https://www.drupal.org/user/213194"
+                },
+                {
+                    "name": "TR",
+                    "homepage": "https://www.drupal.org/user/202830"
+                },
+                {
+                    "name": "vijaycs85",
+                    "homepage": "https://www.drupal.org/user/93488"
+                }
+            ],
+            "description": "Mitigates spam form submissions using the honeypot method.",
+            "homepage": "https://www.drupal.org/project/honeypot",
+            "keywords": [
+                "deterrent",
+                "form",
+                "honeypot",
+                "honeytrap",
+                "php",
+                "spam"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/honeypot",
+                "issues": "https://www.drupal.org/project/issues/honeypot"
             }
         },
         {

--- a/config/default/antibot.settings.yml
+++ b/config/default/antibot.settings.yml
@@ -1,0 +1,9 @@
+_core:
+  default_config_hash: 2TnP0TViNExHGuA7Cdr4L3uxhYGNzKyL0XnoAhtSHMQ
+form_ids:
+  - 'comment_*'
+  - user_login_form
+  - user_pass
+  - user_register_form
+  - 'contact_message_*'
+show_form_ids: false

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -4,6 +4,7 @@ module:
   address: 0
   admin_toolbar: 0
   admin_toolbar_tools: 0
+  antibot: 0
   automated_cron: 0
   autosave_form: 0
   block: 0
@@ -77,6 +78,7 @@ module:
   health_check_url: 0
   help: 0
   history: 0
+  honeypot: 0
   image: 0
   image_widget_crop: 0
   inline_entity_form: 0

--- a/config/default/honeypot.settings.yml
+++ b/config/default/honeypot.settings.yml
@@ -1,0 +1,35 @@
+_core:
+  default_config_hash: w4afsDnzAk9K2ZOYiadiKgRETWY159wYmgznnLvddUs
+protect_all_forms: false
+unprotected_forms:
+  - user_login_form
+  - search_form
+  - search_block_form
+  - views_exposed_form
+  - honeypot_settings_form
+log: false
+element_name: url
+time_limit: 5
+use_js_for_cached_pages: true
+expire: 300
+form_settings:
+  user_register_form: false
+  user_pass: false
+  node_localgov_directories_org_form: false
+  node_localgov_directories_page_form: false
+  node_localgov_directories_venue_form: false
+  node_localgov_directory_form: false
+  node_localgov_directory_promo_page_form: false
+  node_localgov_event_form: false
+  node_localgov_guides_overview_form: false
+  node_localgov_guides_page_form: false
+  node_localgov_newsroom_form: false
+  node_localgov_news_article_form: false
+  node_localgov_services_landing_form: false
+  node_localgov_services_page_form: false
+  node_localgov_services_status_form: false
+  node_localgov_services_sublanding_form: false
+  node_localgov_step_by_step_overview_form: false
+  node_localgov_step_by_step_page_form: false
+  node_localgov_subsites_overview_form: false
+  node_localgov_subsites_page_form: false

--- a/config/default/ultimate_cron.job.honeypot_cron.yml
+++ b/config/default/ultimate_cron.job.honeypot_cron.yml
@@ -1,0 +1,17 @@
+uuid: ef19bd45-0eec-4ff0-ba00-5ae35854dd8a
+langcode: en
+status: true
+dependencies:
+  module:
+    - honeypot
+title: 'Default cron handler'
+id: honeypot_cron
+weight: 0
+module: honeypot
+callback: honeypot_cron
+scheduler:
+  id: simple
+launcher:
+  id: serial
+logger:
+  id: database


### PR DESCRIPTION
https://eccservicetransformation.atlassian.net/browse/LP-119
for essex.gov

Installs and configures Antibot and Honeypot and the JS patch.

You know it has worked if Webforms have third party settings for Honeypot and Antibot. Webforms are treated as content so both protections can be turned on by form creators/editors on each form.