### PR TITLE
LP-101: Update ecc_theme to 1.1.7 for X icon.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9384,16 +9384,16 @@
         },
         {
             "name": "essexcountycouncil/ecc_theme",
-            "version": "1.1.5",
+            "version": "1.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/essexcountycouncil/ecc_theme.git",
-                "reference": "16c7d369050525fa04e2faef6abb7038e5fc7537"
+                "reference": "d682c2e192d0ee7f62e99315c5f338acce18ba26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/essexcountycouncil/ecc_theme/zipball/16c7d369050525fa04e2faef6abb7038e5fc7537",
-                "reference": "16c7d369050525fa04e2faef6abb7038e5fc7537",
+                "url": "https://api.github.com/repos/essexcountycouncil/ecc_theme/zipball/d682c2e192d0ee7f62e99315c5f338acce18ba26",
+                "reference": "d682c2e192d0ee7f62e99315c5f338acce18ba26",
                 "shasum": ""
             },
             "type": "drupal-theme",
@@ -9405,10 +9405,10 @@
             ],
             "description": "Consolidated Essex County Council Drupal theme",
             "support": {
-                "source": "https://github.com/essexcountycouncil/ecc_theme/tree/1.1.5",
+                "source": "https://github.com/essexcountycouncil/ecc_theme/tree/1.1.7",
                 "issues": "https://github.com/essexcountycouncil/ecc_theme/issues"
             },
-            "time": "2024-06-19T06:20:31+00:00"
+            "time": "2024-07-30T11:01:52+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",


### PR DESCRIPTION
## Include a summary of what this merge request involves (*)
Update ecc_theme to 1.1.7. Includes:
- LP-101: Replace Twitter bird with X icon
- LP-124: Create template for service sub-landing to include an h2 to meet WCAG
- LP-125: Add right padding to accordion button to avoid clash at high zoom.
- LP-160: Make tabs region sticky immediately below toolbar.

## Call out any relevant implementation decisions
- Are there any links to back up your chosen methodology?
- Why have you taken the approach?
- Any particular problem areas?
## If necessary, please include any relevant screenshots (If not already available on the JIRA ticket)
## This PR has been tested in the following browsers
- [ ] Arc
- [ ] Edge
- [ ] Chrome
- [ ] Safari
- [ ] Firefox
- [ ] IE 11 (Windows)
- [ ] iOS Chrome
- [ ] iOS Safari
- [ ] Android Chrome
- [ ] Android Firefox
- [ ] Android default
