### PR TITLE
Add circular image style for media with text paragraph

### DIFF
--- a/config/default/field.storage.paragraph.localgov_media_with_text_style.yml
+++ b/config/default/field.storage.paragraph.localgov_media_with_text_style.yml
@@ -19,6 +19,9 @@ settings:
     -
       value: featured
       label: Featured
+    -
+      value: circle
+      label: Circle
   allowed_values_function: ''
 module: options
 locked: false


### PR DESCRIPTION
includes `circle` as an option for the `style` field on media-with-text component.
Config only. Theme stuff is already present.
