### PR TITLE
Use h3 instead of fieldset for directory page enquiries field group.

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
@@ -42,10 +42,19 @@ third_party_settings:
       parent_name: ''
       region: content
       weight: 5
-      format_type: fieldset
+      format_type: html_element
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
+        label_as_html: false
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
         description: ''
 _core:
   default_config_hash: CbFJXKJj2tbKrjoN3eXxIA3dl7AWEGsTiqCggpH20uc


### PR DESCRIPTION
config change to swap the fieldset in use in localgov directory page content type to be a `h3` instead of a fieldset.

https://eccservicetransformation.atlassian.net/browse/LP-308