### PR TITLE
Allow white logo for fostering and digital essex subsites

### DIFF
--- a/config/default/field.storage.node.localgov_subsites_theme.yml
+++ b/config/default/field.storage.node.localgov_subsites_theme.yml
@@ -19,6 +19,9 @@ settings:
     -
       value: fostering
       label: Fostering
+    -
+      value: digitalessex
+      label: 'Digital Essex'
   allowed_values_function: ''
 module: options
 locked: false

--- a/web/modules/custom/ecc_subsites/ecc_subsites.module
+++ b/web/modules/custom/ecc_subsites/ecc_subsites.module
@@ -24,7 +24,9 @@ function ecc_subsites_preprocess_block(&$variables) {
     $subSiteService = \Drupal::service('localgov_subsites_extras.service');
 
     if ($subSiteService->getHomePage()) {
-      if ($subSiteService->getCurrentSubsiteTheme() === 'fostering') {
+      $white_logo_themes = ['fostering', 'digitalessex'];
+      $theme = $subSiteService->getCurrentSubsiteTheme();
+      if (in_array($theme, $white_logo_themes)) {
         $variables['content']['site_logo']['#uri'] = '/themes/contrib/ecc_theme/ecc_theme_gov/assets/images/ECC_logo_long_white.svg';
       }
     }


### PR DESCRIPTION
ecc_subsites sets a white ecc logo for fostering already.
we now also include digital essex as a white-logo subsite theme.
https://eccservicetransformation.atlassian.net/jira/software/projects/LP/boards/25?selectedIssue=LP-232