### PR TITLE
Turn on 'draft' setting for the gov theme

### DIFF
--- a/config/default/ecc_theme_gov.settings.yml
+++ b/config/default/ecc_theme_gov.settings.yml
@@ -1,0 +1,13 @@
+localgov_base_remove_css: false
+localgov_base_remove_js: false
+localgov_base_add_unpublished_background_colour: false
+localgov_base_add_draft_note_to_unpublished_content: true
+features:
+  node_user_picture: true
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 1


### PR DESCRIPTION
theme setting for ecc_theme_gov to turn on the "prepend DRAFT to node titles when they are unpublished" feature.
https://eccservicetransformation.atlassian.net/browse/LP-48