### PR TITLE
Set enquiries fieldset to be h2 on directories page

### DIFF
--- a/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
+++ b/config/default/core.entity_view_display.node.localgov_directories_page.default.yml
@@ -49,13 +49,12 @@ third_party_settings:
         id: ''
         label_as_html: false
         element: div
-        show_label: false
-        label_element: h3
+        show_label: true
+        label_element: h2
         label_element_classes: ''
         attributes: ''
         effect: none
         speed: fast
-        description: ''
 _core:
   default_config_hash: CbFJXKJj2tbKrjoN3eXxIA3dl7AWEGsTiqCggpH20uc
 id: node.localgov_directories_page.default


### PR DESCRIPTION
Set directories page enquiries field fieldset to use h2 as label
https://eccservicetransformation.atlassian.net/browse/LP-308