### PR TITLE
Patch field formatter class module to prevent WSOD when not in an ent…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -236,6 +236,9 @@
             },
             "localgovdrupal/localgov_paragraphs": {
                 "Set type of buttons in accordions to prevent form submission": "patches/localgov-accordion-button-type.patch"
+            },
+            "drupal/field_formatter_class": {
+              "prevent WSOD when in a form that is not an entity form.": "https://git.drupalcode.org/project/field_formatter_class/-/commit/e17b4c2553dec42e5f344036e1e5f2f45b51287f.patch"
             }
         },
         "drupal-scaffold": {


### PR DESCRIPTION
…ity form.

came to light from this card: https://eccservicetransformation.atlassian.net/browse/LP-336
Field formatter class falls over if it is a form that is not an entity form. That situation arrises when editing nested paragraphs in layout-paragraphs on the Fostering page.
Uses this patch: 
https://git.drupalcode.org/project/field_formatter_class/-/commit/e17b4c2553dec42e5f344036e1e5f2f45b51287f.patch
from this issue
https://www.drupal.org/project/field_formatter_class/issues/3473891
